### PR TITLE
管理画面改修

### DIFF
--- a/ha-business/src/main/java/jp/co/ha/business/dto/NewsListDto.java
+++ b/ha-business/src/main/java/jp/co/ha/business/dto/NewsListDto.java
@@ -56,12 +56,9 @@ public class NewsListDto {
         /** 詳細 */
         @JsonProperty("detail")
         private String detail;
-        /** タグ色 */
-        @JsonProperty("tag_color")
-        private String tagColor;
-        /** タグ名 */
-        @JsonProperty("tag_name")
-        private String tagName;
+        /** タグ */
+        @JsonProperty("tag")
+        private Tag tag;
 
         /**
          * indexを返す
@@ -140,42 +137,77 @@ public class NewsListDto {
         }
 
         /**
-         * tagColorを返す
+         * tagを返す
          *
-         * @return tagColor
+         * @return tag
          */
-        public String getTagColor() {
-            return tagColor;
+        public Tag getTag() {
+            return tag;
         }
 
         /**
-         * tagColorを設定する
+         * tagを設定する
          *
-         * @param tagColor
-         *     タグ色
+         * @param tag
+         *     タグ
          */
-        public void setTagColor(String tagColor) {
-            this.tagColor = tagColor;
+        public void setTag(Tag tag) {
+            this.tag = tag;
+        }
+
+    }
+
+    /**
+     * タグ情報
+     *
+     * @version 1.0.0
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Tag {
+
+        /** 色 */
+        @JsonProperty("color")
+        private String color;
+        /** 名前 */
+        @JsonProperty("name")
+        private String name;
+
+        /**
+         * colorを返す
+         *
+         * @return color
+         */
+        public String getColor() {
+            return color;
         }
 
         /**
-         * tagNameを返す
+         * colorを設定する
          *
-         * @return tagName
+         * @param color
+         *     色
          */
-        public String getTagName() {
-            return tagName;
+        public void setColor(String color) {
+            this.color = color;
         }
 
         /**
-         * tagNameを設定する
+         * nameを返す
          *
-         * @param tagName
-         *     タグ名
+         * @return name
          */
-        public void setTagName(String tagName) {
-            this.tagName = tagName;
+        public String getName() {
+            return name;
         }
 
+        /**
+         * nameを設定する
+         *
+         * @param name
+         *     名前
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
     }
 }

--- a/ha-dashboard/src/main/java/jp/co/ha/dashboard/view/DashboardBreadcrumbViewFactory.java
+++ b/ha-dashboard/src/main/java/jp/co/ha/dashboard/view/DashboardBreadcrumbViewFactory.java
@@ -1,7 +1,7 @@
 package jp.co.ha.dashboard.view;
 
-import jp.co.ha.common.util.BreadcrumbView;
-import jp.co.ha.common.util.BreadcrumbView.Breadcrumb;
+import jp.co.ha.web.view.BreadcrumbView;
+import jp.co.ha.web.view.BreadcrumbView.Breadcrumb;
 
 /**
  * ダッシュボードのパンくず情報ViewのFactoryクラス
@@ -9,6 +9,12 @@ import jp.co.ha.common.util.BreadcrumbView.Breadcrumb;
  * @version 1.0.0
  */
 public class DashboardBreadcrumbViewFactory {
+
+    /**
+     * プライベートコンストラクタ
+     */
+    private DashboardBreadcrumbViewFactory() {
+    }
 
     /**
      * デフォルトのパンくずリスト情報Viewを返す

--- a/ha-dashboard/src/main/java/jp/co/ha/dashboard/view/DashboardView.java
+++ b/ha-dashboard/src/main/java/jp/co/ha/dashboard/view/DashboardView.java
@@ -1,7 +1,7 @@
 package jp.co.ha.dashboard.view;
 
-import jp.co.ha.common.util.BreadcrumbView;
 import jp.co.ha.web.view.BaseView;
+import jp.co.ha.web.view.BreadcrumbView;
 
 /**
  * 健康管理View列挙

--- a/ha-dashboard/src/main/webapp/WEB-INF/views/layout/template.html
+++ b/ha-dashboard/src/main/webapp/WEB-INF/views/layout/template.html
@@ -42,8 +42,8 @@
 
     <nav aria-label="パンくずリスト" th:if="${breadcrumbList != null && breadcrumbList.size() != 0}">
       <ol class="breadcrumb">
-        <li class="breadcrumb-item active" aria-current="page" th:each="breadcrumb : ${breadcrumbList}">
-          <a th:href="@{${breadcrumb.url}}" th:text="${breadcrumb.viewName}"></a>
+        <li class="breadcrumb-item active" aria-current="page" th:each="breadcrumb, status : ${breadcrumbList}" th:object="${breadcrumb}">
+          <a th:href="@{*{url}}" th:text="*{viewName}"></a>
         </li><!-- /.breadcrumb-item active -->
       </ol><!-- /.breadcrumb -->
     </nav>

--- a/ha-dashboard/src/main/webapp/WEB-INF/views/news/list.html
+++ b/ha-dashboard/src/main/webapp/WEB-INF/views/news/list.html
@@ -21,11 +21,11 @@
                <td class="card card-body bg-light">
                  <div>
                    <!-- リリース情報 -->
-                   <span class="badge badge-primary" th:if="${news.tagColor == '1'}" th:text="${news.tagName}"></span>
+                   <span class="badge badge-primary" th:if="${news.tag.color == 'blue'}" th:text="${news.tag.name}"></span>
                    <!-- バグ情報 -->
-                   <span class="badge badge-danger" th:if="${news.tagColor == '2'}" th:text="${news.tagName}"></span>
+                   <span class="badge badge-danger" th:if="${news.tag.color == 'red'}" th:text="${news.tag.name}"></span>
                    <!-- 停止情報 -->
-                   <span class="badge badge-warning" th:if="${news.tagColor == '3'}" th:text="${news.tagName}"></span>
+                   <span class="badge badge-warning" th:if="${news.tag.color == 'yellow'}" th:text="${news.tag.name}"></span>
                  </div>
                  <a data-toggle="collapse" th:href="${'#newsId' + news.index}" role="button" aria-expanded="false" th:aria-controls="${'newsId' + news.index}" th:text="${news.date + '　' + news.title}"></a>
                  <div class="collapse" th:id="${'newsId' + news.index}">

--- a/ha-db/src/main/java/jp/co/ha/db/entity/composite/CompositeAccount.java
+++ b/ha-db/src/main/java/jp/co/ha/db/entity/composite/CompositeAccount.java
@@ -2,6 +2,7 @@ package jp.co.ha.db.entity.composite;
 
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import jp.co.ha.common.db.annotation.Crypt;
 import jp.co.ha.common.db.annotation.Entity;
@@ -35,6 +36,10 @@ public class CompositeAccount extends CompositeAccountKey implements Serializabl
     private String apiKey;
     /** パスワード有効期限 */
     private LocalDate passwordExpire;
+    /** 登録日時 */
+    private LocalDateTime regDate;
+    /** 更新日時 */
+    private LocalDateTime updateDate;
     /** ヘッダ利用有無フラグ */
     private String headerFlag;
     /** フッタ利用有無フラグ */
@@ -156,6 +161,44 @@ public class CompositeAccount extends CompositeAccountKey implements Serializabl
      */
     public void setPasswordExpire(LocalDate passwordExpire) {
         this.passwordExpire = passwordExpire;
+    }
+
+    /**
+     * regDateを返す
+     *
+     * @return regDate
+     */
+    public LocalDateTime getRegDate() {
+        return regDate;
+    }
+
+    /**
+     * regDateを設定する
+     *
+     * @param regDate
+     *     登録日時
+     */
+    public void setRegDate(LocalDateTime regDate) {
+        this.regDate = regDate;
+    }
+
+    /**
+     * updateDateを返す
+     *
+     * @return updateDate
+     */
+    public LocalDateTime getUpdateDate() {
+        return updateDate;
+    }
+
+    /**
+     * updateDateを設定する
+     *
+     * @param updateDate
+     *     更新日時
+     */
+    public void setUpdateDate(LocalDateTime updateDate) {
+        this.updateDate = updateDate;
     }
 
     /**

--- a/ha-db/src/main/resources/jp/co/ha/db/mapper/composite/CompositeAccountMapper.xml
+++ b/ha-db/src/main/resources/jp/co/ha/db/mapper/composite/CompositeAccountMapper.xml
@@ -8,6 +8,8 @@
     <result column="PASSWORD_EXPIRE" jdbcType="DATE" property="passwordExpire" />
     <result column="REMARKS" jdbcType="VARCHAR" property="remarks" />
     <result column="API_KEY" jdbcType="VARCHAR" property="apiKey" />
+    <result column="REG_DATE" jdbcType="TIMESTAMP" property="regDate" />
+    <result column="UPDATE_DATE" jdbcType="TIMESTAMP" property="updateDate" />
     <result column="MAIL_ADDRESS" jdbcType="VARCHAR" property="mailAddress" />
     <result column="HEADER_FLAG" jdbcType="VARCHAR" property="headerFlag" />
     <result column="FOOTER_FLAG" jdbcType="VARCHAR" property="footerFlag" />
@@ -24,6 +26,8 @@
       , AC.REMARKS
       , AC.API_KEY
       , AC.MAIL_ADDRESS
+      , AC.REG_DATE
+      , AC.UPDATE_DATE
       <!-- HEALTH_INFO_FILE_SETTING -->
       , HF.HEADER_FLAG
       , HF.FOOTER_FLAG
@@ -46,6 +50,8 @@
       , AC.REMARKS
       , AC.API_KEY
       , AC.MAIL_ADDRESS
+      , AC.REG_DATE
+      , AC.UPDATE_DATE
       <!-- HEALTH_INFO_FILE_SETTING -->
       , HF.HEADER_FLAG
       , HF.FOOTER_FLAG

--- a/ha-root/front/assets/variables.scss
+++ b/ha-root/front/assets/variables.scss
@@ -2,3 +2,49 @@
 //
 // The variables you want to modify
 // $font-size-root: 20px;
+
+// ローディング処理
+.custom-loader {
+  animation: loader 1s infinite;
+  display: flex;
+}
+
+@-moz-keyframes loader {
+  from {
+    transform: rotate(0);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@-webkit-keyframes loader {
+  from {
+    transform: rotate(0);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@-o-keyframes loader {
+  from {
+    transform: rotate(0);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes loader {
+  from {
+    transform: rotate(0);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/ha-root/front/components/AppLoginInfo.vue
+++ b/ha-root/front/components/AppLoginInfo.vue
@@ -6,10 +6,10 @@
 
 <script>
 export default {
-  data: function() {
+  data: function () {
     return {
-      messagePrefix: 'ログインID'
-    }
+      messagePrefix: "ログインID",
+    };
   },
   methods: {
     editLoginUser: function () {
@@ -17,8 +17,8 @@ export default {
     },
   },
   computed: {
-    viewLoginUser: function() {
-      return this.messagePrefix + "：" + this.$store.state.auth.seq_login_id
+    viewLoginUser: function () {
+      return this.messagePrefix + "：" + this.$store.state.auth.seq_login_id;
     },
   },
 };

--- a/ha-root/front/components/AppLogout.vue
+++ b/ha-root/front/components/AppLogout.vue
@@ -7,10 +7,10 @@
 
 <script>
 export default {
-  data: function() {
+  data: function () {
     return {
-      message: 'ログアウト'
-    }
+      message: "ログアウト",
+    };
   },
   methods: {
     logout: function () {

--- a/ha-root/front/components/AppTheme.vue
+++ b/ha-root/front/components/AppTheme.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-switch v-model="theme" class="theme-postion" :prepend-icon="themeIcon"></v-switch>
+  <v-switch
+    v-model="theme"
+    class="theme-postion"
+    :prepend-icon="themeIcon"
+  ></v-switch>
 </template>
 
 <script>

--- a/ha-root/front/components/AppTitle.vue
+++ b/ha-root/front/components/AppTitle.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col class="text-center">
-      <h1><v-icon class="icon">{{ icon }}</v-icon>{{ title }}</h1>
+      <h1><v-icon class="icon" size="35">{{ icon }}</v-icon>{{ title }}</h1>
     </v-col>
   </v-row>
 </template>
@@ -17,7 +17,7 @@ export default {
 
 <style scoped>
 .icon {
-  margin: 0;
-  padding: 0;
+  padding-right: 10px;
+  padding-bottom: 7px;
 }
 </style>

--- a/ha-root/front/components/AppTitle.vue
+++ b/ha-root/front/components/AppTitle.vue
@@ -1,7 +1,10 @@
 <template>
   <v-row>
     <v-col class="text-center">
-      <h1><v-icon class="icon" size="35">{{ icon }}</v-icon>{{ title }}</h1>
+      <h1>
+        <v-icon class="icon" size="35">{{ icon }}</v-icon
+        >{{ title }}
+      </h1>
     </v-col>
   </v-row>
 </template>

--- a/ha-root/front/components/AppVuetifyLogo.vue
+++ b/ha-root/front/components/AppVuetifyLogo.vue
@@ -1,5 +1,5 @@
 <template>
-  <img class="VuetifyLogo" alt="Vuetify Logo" src="/vuetify-logo.svg">
+  <img class="VuetifyLogo" alt="Vuetify Logo" src="/vuetify-logo.svg" />
 </template>
 
 <style scoped>

--- a/ha-root/front/components/news/NewsEdit.vue
+++ b/ha-root/front/components/news/NewsEdit.vue
@@ -48,7 +48,12 @@
           </v-form>
         </v-card-text>
         <v-card-actions>
-          <v-btn color="primary" @click="submit">
+          <v-btn
+            color="primary"
+            @click="submit"
+            :loading="loading"
+            :disabled="loading"
+          >
             <v-icon>mdi-comment-edit</v-icon>&ensp;更新
           </v-btn>
         </v-card-actions>
@@ -75,6 +80,7 @@ export default {
   data: function () {
     return {
       isDispCalendar: false,
+      loading: false,
     };
   },
   methods: {
@@ -82,6 +88,7 @@ export default {
       this.isDispCalendar = !this.isDispCalendar;
     },
     submit: function () {
+      this.loading = true;
       let headers = {
         Authorization: this.$store.state.auth.token,
       };
@@ -110,6 +117,7 @@ export default {
 
             // お知らせ情報更新後、最新のお知らせ情報を取得する
             this.$emit("get-news");
+            this.loading = false;
           }
         },
         (error) => {

--- a/ha-root/front/components/news/NewsEdit.vue
+++ b/ha-root/front/components/news/NewsEdit.vue
@@ -36,17 +36,12 @@
               label="詳細(htmlタグの入力も可能です)"
               clearable
             ></v-textarea>
-            <v-select
-              v-model="edit_news_form.tag_color"
-              :items="tag_color_select_list"
-              label="タグ色"
-              item-text="label"
-              item-value="value"
-              return-object
-              single-line
-            ></v-select>
+            <NewsTagPullDown
+              v-model="edit_news_form.tag.color"
+              :color="edit_news_form.tag.color"
+            />
             <v-text-field
-              v-model="edit_news_form.tag_name"
+              v-model="edit_news_form.tag.name"
               label="タグ名"
               clearable
             ></v-text-field>
@@ -65,13 +60,14 @@
 
 <script>
 import ProcessFinishModal from "~/components/modal/ProcessFinishModal.vue";
-
+import NewsTagPullDown from "~/components/news/NewsTagPullDown.vue";
 const axios = require("axios");
 let url = process.env.api_base_url + "news/";
 
 export default {
   components: {
     ProcessFinishModal,
+    NewsTagPullDown,
   },
   props: {
     edit_news_form: Object,
@@ -79,20 +75,6 @@ export default {
   data: function () {
     return {
       isDispCalendar: false,
-      tag_color_select_list: [
-        {
-          value: "1",
-          label: "1(blue)",
-        },
-        {
-          value: "2",
-          label: "2(yellow)",
-        },
-        {
-          value: "3",
-          label: "3(red)",
-        },
-      ],
     };
   },
   methods: {
@@ -102,22 +84,23 @@ export default {
     submit: function () {
       let headers = {
         Authorization: this.$store.state.auth.token,
-      }
+      };
       let reqUrl = url + this.edit_news_form.index;
       let reqBody = {
         index: this.edit_news_form.index,
         title: this.edit_news_form.title,
         date: this.edit_news_form.date.replaceAll("-", "/"),
         detail: this.edit_news_form.detail,
-        tag_color: this.edit_news_form.tag_color.value,
-        tag_name: this.edit_news_form.tag_name,
+        tag: {
+          color: this.edit_news_form.tag.color,
+          name: this.edit_news_form.tag.name,
+        },
       };
       console.log(JSON.stringify(reqBody, null, "\t"));
 
       axios.put(reqUrl, reqBody, { headers }).then(
         (result) => {
           if (result.data.result == 0) {
-
             // 処理完了モーダルを表示
             let json = JSON.stringify(this.edit_news_form, null, "\t");
             this.$refs.finish.open("お知らせ情報更新処理", json, {

--- a/ha-root/front/components/news/NewsEntry.vue
+++ b/ha-root/front/components/news/NewsEntry.vue
@@ -22,18 +22,13 @@
                 @input="controllCalendar"
               ></v-date-picker>
             </template>
-            <v-textarea v-model="entry_info.detail" label="詳細(htmlタグの入力も可能です)"></v-textarea>
-            <v-select
-              v-model="entry_info.tag_color"
-              :items="tag_color_select_list"
-              label="タグ色"
-              item-text="label"
-              item-value="value"
-              return-object
-              single-line
-            ></v-select>
+            <v-textarea
+              v-model="entry_info.detail"
+              label="詳細(htmlタグの入力も可能です)"
+            ></v-textarea>
+            <NewsTagPullDown v-model="entry_info.tag.color" color="blue" />
             <v-text-field
-              v-model="entry_info.tag_name"
+              v-model="entry_info.tag.name"
               label="タグ名"
             ></v-text-field>
           </v-form>
@@ -51,6 +46,7 @@
 
 <script>
 import ProcessFinishModal from "~/components/modal/ProcessFinishModal.vue";
+import NewsTagPullDown from "~/components/news/NewsTagPullDown.vue";
 
 const axios = require("axios");
 let url = process.env.api_base_url + "news";
@@ -58,30 +54,19 @@ let url = process.env.api_base_url + "news";
 export default {
   components: {
     ProcessFinishModal,
+    NewsTagPullDown,
   },
   data: function () {
     return {
       isDispCalendar: false,
-      tag_color_select_list: [
-        {
-          value: "1",
-          label: "1(blue)",
-        },
-        {
-          value: "2",
-          label: "2(yellow)",
-        },
-        {
-          value: "3",
-          label: "3(red)",
-        },
-      ],
       entry_info: {
         title: "",
         date: new Date().toISOString().substr(0, 10),
         detail: "",
-        tag_color: "",
-        tag_name: "",
+        tag: {
+          color: "",
+          name: "",
+        },
       },
       api_data: {
         api_result: "",
@@ -90,8 +75,10 @@ export default {
           title: "",
           date: "",
           detail: "",
-          tag_color: "",
-          tag_name: "",
+          tag: {
+            color: "",
+            name: "",
+          },
         },
       },
     };
@@ -101,19 +88,22 @@ export default {
       this.isDispCalendar = !this.isDispCalendar;
     },
     submit: function () {
-      let params = new URLSearchParams();
-      params.append("title", this.entry_info.title);
-      params.append("date", this.entry_info.date.replaceAll("-", "/"));
-      params.append("detail", this.entry_info.detail);
-      params.append("tag_color", this.entry_info.tag_color.value);
-      params.append("tag_name", this.entry_info.tag_name);
-      // 保存済のAPIトークンを取得
-      let token = this.$store.state.auth.token;
-      let headers = {
-        Authorization: token,
+      let reqBody = {
+        index: this.entry_info.index,
+        title: this.entry_info.title,
+        date: this.entry_info.date.replaceAll("-", "/"),
+        detail: this.entry_info.detail,
+        tag: {
+          color: this.entry_info.tag.color,
+          name: this.entry_info.tag.name,
+        },
       };
 
-      axios.post(url, params, { headers }).then(
+      let headers = {
+        Authorization: this.$store.state.auth.token,
+      };
+      console.log(JSON.stringify(reqBody, null, "\t"));
+      axios.post(url, reqBody, { headers }).then(
         (result) => {
           if (result.data.result == 0) {
             // お知らせ情報登録APIが正常終了した場合

--- a/ha-root/front/components/news/NewsEntry.vue
+++ b/ha-root/front/components/news/NewsEntry.vue
@@ -34,7 +34,12 @@
           </v-form>
         </v-card-text>
         <v-card-actions>
-          <v-btn color="primary" @click="submit">
+          <v-btn
+            color="primary"
+            @click="submit"
+            :loading="loading"
+            :disabled="loading"
+          >
             <v-icon>mdi-newspaper-plus</v-icon>&ensp;登録
           </v-btn>
         </v-card-actions>
@@ -59,6 +64,7 @@ export default {
   data: function () {
     return {
       isDispCalendar: false,
+      loading: false,
       entry_info: {
         title: "",
         date: new Date().toISOString().substr(0, 10),
@@ -88,6 +94,7 @@ export default {
       this.isDispCalendar = !this.isDispCalendar;
     },
     submit: function () {
+      this.loading = true;
       let reqBody = {
         index: this.entry_info.index,
         title: this.entry_info.title,
@@ -119,10 +126,13 @@ export default {
 
             // お知らせ情報登録後、最新のお知らせ情報を取得する
             this.$emit("get-news");
+
+            this.loading = false;
           }
         },
         (error) => {
           console.log("[error]=" + error);
+          this.loading = false;
           return error;
         }
       );

--- a/ha-root/front/components/news/NewsTagPullDown.vue
+++ b/ha-root/front/components/news/NewsTagPullDown.vue
@@ -1,0 +1,60 @@
+<template>
+  <v-select
+    :items="tag_color_select_list"
+    label="タグ色"
+    item-text="label"
+    item-value="color"
+    return-object
+    single-line
+    :value="init"
+    @change="updateValue"
+  ></v-select>
+</template>
+
+<script>
+export default {
+  data: function () {
+    return {
+      tag_color_select_list: [
+        {
+          color: "blue",
+          label: "青色",
+        },
+        {
+          color: "yellow",
+          label: "黄色",
+        },
+        {
+          color: "red",
+          label: "赤色",
+        },
+      ],
+    };
+  },
+  props: {
+    color: { type: String, required: false },
+  },
+  computed: {
+    init: function () {
+      return this.getTag(this.color);
+    },
+  },
+  methods: {
+    updateValue: function (e) {
+      console.log("変更後色=" + e.color);
+      this.$emit("input", e.color);
+    },
+    getTag: function (color) {
+      for (var i = 0; i < this.tag_color_select_list.length; i++) {
+        let tag = this.tag_color_select_list[i];
+        if (tag.color == color) {
+          return tag;
+        }
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/ha-root/front/components/news/NewsTagPullDown.vue
+++ b/ha-root/front/components/news/NewsTagPullDown.vue
@@ -51,7 +51,11 @@ export default {
           return tag;
         }
       }
+      return this.tag_color_select_list[0];
     },
+  },
+  mounted: function () {
+    this.$emit("input", this.tag_color_select_list[0].color);
   },
 };
 </script>

--- a/ha-root/front/pages/account/index.vue
+++ b/ha-root/front/pages/account/index.vue
@@ -60,6 +60,14 @@ export default {
           value: "api_key",
         },
         {
+          text: "登録日時",
+          value: "reg_date",
+        },
+        {
+          text: "更新日時",
+          value: "update_date",
+        },
+        {
           text: "ヘッダ利用有無フラグ",
           value: "header_flag",
         },
@@ -81,11 +89,9 @@ export default {
   },
 
   created: function () {
-    // 保存済のAPIトークンを取得
-    let token = this.$store.state.auth.token;
     
     axios.get(url, {
-      headers: { "Authorization": token },
+      headers: { "Authorization": this.$store.state.auth.token },
     }).then((response) => {
       this.account_list = response.data.account_list;
     }, (error) => {
@@ -93,16 +99,6 @@ export default {
       return error;
     });
   },
-
-  // asyncData: async function () {
-  //   // アカウント情報一覧取得API 実行
-  //   // ユーザ情報を取得
-  //   console.log("[data]=" + this.$store.state.auth.user);
-  //   let result = await axios.get(url);
-  //   return {
-  //     account_list: result.data.account_list,
-  //   };
-  // },
 };
 </script>
 

--- a/ha-root/front/pages/account/index.vue
+++ b/ha-root/front/pages/account/index.vue
@@ -84,20 +84,23 @@ export default {
           value: "enclosure_char_flag",
         },
       ],
-
     };
   },
 
   created: function () {
-    
-    axios.get(url, {
-      headers: { "Authorization": this.$store.state.auth.token },
-    }).then((response) => {
-      this.account_list = response.data.account_list;
-    }, (error) => {
-      console.log('[error]=' + error);
-      return error;
-    });
+    axios
+      .get(url, {
+        headers: { Authorization: this.$store.state.auth.token },
+      })
+      .then(
+        (response) => {
+          this.account_list = response.data.account_list;
+        },
+        (error) => {
+          console.log("[error]=" + error);
+          return error;
+        }
+      );
   },
 };
 </script>

--- a/ha-root/front/pages/apidata/index.vue
+++ b/ha-root/front/pages/apidata/index.vue
@@ -81,7 +81,6 @@ export default {
     };
   },
   created: function () {
-
     axios
       .get(url, {
         headers: { Authorization: this.$store.state.auth.token },

--- a/ha-root/front/pages/healthinfo/index.vue
+++ b/ha-root/front/pages/healthinfo/index.vue
@@ -26,11 +26,11 @@ import AppTitle from "~/components/AppTitle.vue";
 const axios = require("axios");
 let url = process.env.api_base_url + "healthinfo";
 
-export default{
+export default {
   components: {
     AppTitle,
   },
-  data: function() {
+  data: function () {
     return {
       search: "",
       health_info_list: [],
@@ -71,25 +71,29 @@ export default{
           text: "健康情報登録日時",
           value: "health_info_reg_date",
         },
-      ]
-    }
+      ],
+    };
   },
   created: function () {
     // 保存済のAPIトークンを取得
     let token = this.$store.state.auth.token;
-    
-    axios.get(url, {
-      headers: { "Authorization": token },
-    }).then((response) => {
-      this.health_info_list = response.data.health_info_list;
-    }, (error) => {
-      console.log('[error]=' + error);
-      return error;
-    });
+
+    axios
+      .get(url, {
+        headers: { Authorization: token },
+      })
+      .then(
+        (response) => {
+          this.health_info_list = response.data.health_info_list;
+        },
+        (error) => {
+          console.log("[error]=" + error);
+          return error;
+        }
+      );
   },
-}
+};
 </script>
 
 <style>
-
 </style>

--- a/ha-root/front/pages/index.vue
+++ b/ha-root/front/pages/index.vue
@@ -10,29 +10,62 @@
           Welcome to the Vuetify + Nuxt.js template
         </v-card-title>
         <v-card-text>
-          <p>Vuetify is a progressive Material Design component framework for Vue.js. It was designed to empower developers to create amazing applications.</p>
           <p>
-            For more information on Vuetify, check out the 
-            <a href="https://vuetifyjs.com" target="_blank" rel="noopener noreferrer">documentation</a>.
+            Vuetify is a progressive Material Design component framework for
+            Vue.js. It was designed to empower developers to create amazing
+            applications.
+          </p>
+          <p>
+            For more information on Vuetify, check out the
+            <a
+              href="https://vuetifyjs.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              >documentation</a
+            >.
           </p>
           <p>
             If you have questions, please join the official
-            <a href="https://chat.vuetifyjs.com/" target="_blank" rel="noopener noreferrer" title="chat">discord</a>.
+            <a
+              href="https://chat.vuetifyjs.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              title="chat"
+              >discord</a
+            >.
           </p>
           <p>
             Find a bug? Report it on the github
-            <a href="https://github.com/vuetifyjs/vuetify/issues" target="_blank" rel="noopener noreferrer" title="contribute">
-              issue board
-            </a>.
+            <a
+              href="https://github.com/vuetifyjs/vuetify/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              title="contribute"
+            >
+              issue board </a
+            >.
           </p>
-          <p>Thank you for developing with Vuetify and I look forward to bringing more exciting features in the future.</p>
+          <p>
+            Thank you for developing with Vuetify and I look forward to bringing
+            more exciting features in the future.
+          </p>
           <div class="text-xs-right">
             <em><small>&mdash; John Leider</small></em>
           </div>
-          <hr class="my-3">
-          <a href="https://nuxtjs.org/" target="_blank" rel="noopener noreferrer">Nuxt Documentation</a>
-          <br>
-          <a href="https://github.com/nuxt/nuxt.js" target="_blank" rel="noopener noreferrer">Nuxt GitHub</a>
+          <hr class="my-3" />
+          <a
+            href="https://nuxtjs.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Nuxt Documentation</a
+          >
+          <br />
+          <a
+            href="https://github.com/nuxt/nuxt.js"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Nuxt GitHub</a
+          >
         </v-card-text>
         <v-card-actions>
           <v-spacer />
@@ -44,13 +77,13 @@
 </template>
 
 <script>
-import AppLogo from '~/components/AppLogo.vue'
-import AppVuetifyLogo from '~/components/AppVuetifyLogo.vue'
+import AppLogo from "~/components/AppLogo.vue";
+import AppVuetifyLogo from "~/components/AppVuetifyLogo.vue";
 
 export default {
   components: {
     AppLogo,
-    AppVuetifyLogo
-  }
-}
+    AppVuetifyLogo,
+  },
+};
 </script>

--- a/ha-root/front/pages/login/index.vue
+++ b/ha-root/front/pages/login/index.vue
@@ -24,7 +24,12 @@
           </v-form>
         </v-card-text>
         <v-card-actions>
-          <v-btn color="primary" @click="submit">
+          <v-btn
+            color="primary"
+            @click="submit"
+            :loading="loading"
+            :disabled="loading"
+          >
             <v-icon>mdi-account-arrow-right</v-icon>&ensp;ログイン
           </v-btn>
           <v-spacer />
@@ -47,6 +52,7 @@ export default {
       seq_login_id: "",
       password: "",
       show: false,
+      loading: false,
       required: (value) => !!value || "必ず入力してください",
     };
   },
@@ -66,6 +72,7 @@ export default {
   },
   methods: {
     submit: function () {
+      this.loading = true;
       if (!this.$refs.login_form.validate()) {
         // 入力値エラーの場合
         return;
@@ -89,17 +96,7 @@ export default {
               token: authorization,
             });
 
-            // let list = this.$store.state.auth.auth_data_list;
-            // let value = null;
-            // for (var i = 0; i < list.length; i++) {
-            //   let auth_data = list[i];
-            //   if (auth_data.seq_login_id == this.seq_login_id) {
-            //     // 同一ログインIDの場合、トークン取得
-            //     value = auth_data.token;
-            //     break;
-            //   }
-            // }
-            // console.log("[saved token]=" + value);
+            this.loading = false;
 
             return response;
           },

--- a/ha-root/front/pages/news/index.vue
+++ b/ha-root/front/pages/news/index.vue
@@ -20,7 +20,7 @@
           <!-- v-slotの書き方は以下でないとESLintでエラーになる -->
           <template v-slot:[`item.tag.name`]="{ item }">
             <v-chip
-              :color="getTagColor(item.tag.color)"
+              :color="item.tag.color"
               v-if="item.tag.color != null && item.tag.name != null"
             >
               <b>{{ item.tag.name }}</b>
@@ -35,7 +35,13 @@
             </v-btn>
           </template>
           <template v-slot:[`item.delete_action`]="{ item }">
-            <v-btn small class="mx-1" @click="openNewsDeleteModal(item.index)">
+            <v-btn
+              small
+              class="mx-1"
+              :loading="loading"
+              :disabled="loading"
+              @click="openNewsDeleteModal(item.index)"
+            >
               <v-icon>mdi-delete</v-icon>
             </v-btn>
           </template>
@@ -68,8 +74,10 @@ export default {
   data: function () {
     return {
       entry_mode: true,
+      loading: false,
       search: "",
       news_list: [],
+      api_loading: false,
       headers: [
         {
           text: "",
@@ -102,20 +110,6 @@ export default {
           value: "tag.name",
         },
       ],
-      tag_color_select_list: [
-        {
-          color: "blue",
-          label: "青色",
-        },
-        {
-          color: "yellow",
-          label: "黄色",
-        },
-        {
-          color: "red",
-          label: "赤色",
-        },
-      ],
       edit_news_form: {
         index: "",
         title: "",
@@ -132,14 +126,6 @@ export default {
     this.getNews();
   },
   methods: {
-    getTagColor: function (tag_color) {
-      for (var i = 0; i < this.tag_color_select_list.length; i++) {
-        let tag = this.tag_color_select_list[i];
-        if (tag.color == tag_color) {
-          return tag.color;
-        }
-      }
-    },
     getNews() {
       axios
         .get(url, {
@@ -185,6 +171,7 @@ export default {
       }
     },
     async deleteNews(id) {
+      this.loading = true;
       let deleteUrl = url + "/" + id;
       let headers = {
         Authorization: this.$store.state.auth.token,
@@ -206,6 +193,7 @@ export default {
 
               // おしらせ情報取得
               this.getNews();
+              this.loading = false;
             }
           },
           (error) => {

--- a/ha-root/front/pages/news/index.vue
+++ b/ha-root/front/pages/news/index.vue
@@ -18,12 +18,12 @@
         ></v-text-field>
         <v-data-table :headers="headers" :items="news_list" :search="search">
           <!-- v-slotの書き方は以下でないとESLintでエラーになる -->
-          <template v-slot:[`item.tag_name`]="{ item }">
+          <template v-slot:[`item.tag.name`]="{ item }">
             <v-chip
-              :color="getTagColor(item.tag_color)"
-              v-if="item.tag_color != null && item.tag_name != null"
+              :color="getTagColor(item.tag.color)"
+              v-if="item.tag.color != null && item.tag.name != null"
             >
-              <b>{{ item.tag_name }}</b>
+              <b>{{ item.tag.name }}</b>
             </v-chip>
           </template>
           <template v-slot:[`item.detail`]="{ item }">
@@ -99,24 +99,21 @@ export default {
         },
         {
           text: "タグ名",
-          value: "tag_name",
+          value: "tag.name",
         },
       ],
       tag_color_select_list: [
         {
-          value: "1",
           color: "blue",
-          label: "1(blue)",
+          label: "青色",
         },
         {
-          value: "2",
           color: "yellow",
-          label: "2(yellow)",
+          label: "黄色",
         },
         {
-          value: "3",
           color: "red",
-          label: "3(red)",
+          label: "赤色",
         },
       ],
       edit_news_form: {
@@ -124,8 +121,10 @@ export default {
         title: "",
         date: "",
         detail: "",
-        tag_color: "",
-        tag_name: "",
+        tag: {
+          color: "",
+          name: "",
+        },
       },
     };
   },
@@ -136,17 +135,15 @@ export default {
     getTagColor: function (tag_color) {
       for (var i = 0; i < this.tag_color_select_list.length; i++) {
         let tag = this.tag_color_select_list[i];
-        if (tag.value == tag_color) {
+        if (tag.color == tag_color) {
           return tag.color;
         }
       }
     },
     getNews() {
-      let token = this.$store.state.auth.token;
-
       axios
         .get(url, {
-          headers: { Authorization: token },
+          headers: { Authorization: this.$store.state.auth.token },
         })
         .then(
           (response) => {
@@ -161,13 +158,7 @@ export default {
     changeNewsEditView: function (edit_news_id) {
       for (var i = 0; i < this.news_list.length; i++) {
         let targetNews = this.news_list[i];
-        if (edit_news_id == targetNews.index) {
-          for (var i = 0; i < this.tag_color_select_list.length; i++) {
-            let tag = this.tag_color_select_list[i];
-            if (targetNews.tag_color == tag.value) {
-              targetNews.tag_color = tag;
-            }
-          }
+        if (targetNews.index == edit_news_id) {
           // カレンダー表示に対応させるため、YYYY-MM-DD形式に変換する
           targetNews.date = targetNews.date.replaceAll("/", "-");
           this.edit_news_form = targetNews;
@@ -195,11 +186,12 @@ export default {
     },
     async deleteNews(id) {
       let deleteUrl = url + "/" + id;
-      let token = this.$store.state.auth.token;
-
+      let headers = {
+        Authorization: this.$store.state.auth.token,
+      };
       axios
         .delete(deleteUrl, {
-          headers: { Authorization: token },
+          headers,
         })
         .then(
           (response) => {

--- a/ha-root/front/pages/user/entry/index.vue
+++ b/ha-root/front/pages/user/entry/index.vue
@@ -36,13 +36,24 @@
         <v-card-actions>
           <template v-if="api_data.api_result != '0'">
             <!-- APIが正常終了していない場合 -->
-            <v-btn color="primary" @click="openUserEntryModal" v-on="on">
+            <v-btn
+              color="primary"
+              @click="openUserEntryModal"
+              v-on="on"
+              :loading="loading"
+              :disabled="loading"
+            >
               <v-icon>mdi-account-multiple-plus</v-icon>&ensp;作成
             </v-btn>
           </template>
           <template v-else>
             <!-- APIが正常終了している場合 -->
-            <v-btn color="primary" to="/login">
+            <v-btn
+              color="primary"
+              to="/login"
+              :loading="loading"
+              :disabled="loading"
+            >
               <v-icon>mdi-account-arrow-right</v-icon>&ensp;ログイン
             </v-btn>
           </template>
@@ -74,14 +85,15 @@ export default {
       conf_password: "",
       password_show: false,
       conf_password_show: false,
+      loading: false,
       api_data: {
         api_result: "",
         seq_login_id: "",
       },
       modal: {
-        title: 'ユーザ作成',
-        contents: '',
-      }
+        title: "ユーザ作成",
+        contents: "",
+      },
     };
   },
   computed: {
@@ -106,9 +118,10 @@ export default {
   },
   methods: {
     async openUserEntryModal() {
+      this.loading = true;
       if (
         await this.$refs.confirm.open(this.modal.title, this.modal.contents, {
-          color: 'blue',
+          color: "blue",
           width: 400,
         })
       ) {
@@ -116,15 +129,17 @@ export default {
       }
     },
     entryUser: function () {
-      let params = new URLSearchParams();
-      params.append("password", this.password);
-      params.append("conf_password", this.conf_password);
+      let reqBody = {
+        password: this.password,
+        conf_password: this.conf_password,
+      };
 
-      axios.post(url, params).then((result) => {
+      axios.post(url, reqBody).then((result) => {
         if (result.data.result === "0") {
           // ユーザ作成APIが正常終了した場合
           this.api_data.api_result = result.data.result;
           this.api_data.seq_login_id = result.data.seq_login_id;
+          this.loading = false;
         }
       });
     },
@@ -133,5 +148,4 @@ export default {
 </script>
 
 <style scope>
-
 </style>

--- a/ha-root/src/main/java/jp/co/ha/root/contents/account/response/AccountListApiResponse.java
+++ b/ha-root/src/main/java/jp/co/ha/root/contents/account/response/AccountListApiResponse.java
@@ -1,6 +1,7 @@
 package jp.co.ha.root.contents.account.response;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -8,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 import jp.co.ha.root.base.BaseRootApiResponse;
 import jp.co.ha.root.base.JsonEntity;
@@ -72,6 +74,16 @@ public class AccountListApiResponse extends BaseRootApiResponse
         /** APIキー */
         @JsonProperty("api_key")
         private String apiKey;
+        /** 登録日時 */
+        @JsonProperty("reg_date")
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss", timezone = "Asia/Tokyo")
+        private LocalDateTime regDate;
+        /** 更新日時 */
+        @JsonProperty("update_date")
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss", timezone = "Asia/Tokyo")
+        private LocalDateTime updateDate;
         /** ヘッダ利用有無フラグ */
         @JsonProperty("header_flag")
         private String headerFlag;
@@ -197,6 +209,44 @@ public class AccountListApiResponse extends BaseRootApiResponse
          */
         public void setApiKey(String apiKey) {
             this.apiKey = apiKey;
+        }
+
+        /**
+         * regDateを返す
+         *
+         * @return regDate
+         */
+        public LocalDateTime getRegDate() {
+            return regDate;
+        }
+
+        /**
+         * regDateを設定する
+         *
+         * @param regDate
+         *     登録日時
+         */
+        public void setRegDate(LocalDateTime regDate) {
+            this.regDate = regDate;
+        }
+
+        /**
+         * updateDateを返す
+         *
+         * @return updateDate
+         */
+        public LocalDateTime getUpdateDate() {
+            return updateDate;
+        }
+
+        /**
+         * updateDateを設定する
+         *
+         * @param updateDate
+         *     更新日時
+         */
+        public void setUpdateDate(LocalDateTime updateDate) {
+            this.updateDate = updateDate;
         }
 
         /**

--- a/ha-root/src/main/java/jp/co/ha/root/contents/news/controller/NewsListApiController.java
+++ b/ha-root/src/main/java/jp/co/ha/root/contents/news/controller/NewsListApiController.java
@@ -57,6 +57,10 @@ public class NewsListApiController
                 .map(e -> {
                     NewsListApiResponse.NewsDataResponse response = new NewsListApiResponse.NewsDataResponse();
                     BeanUtil.copy(e, response);
+
+                    NewsListApiResponse.Tag responseTag = new NewsListApiResponse.Tag();
+                    BeanUtil.copy(e.getTag(), responseTag);
+                    response.setTag(responseTag);
                     return response;
                 })
                 .sorted(Comparator

--- a/ha-root/src/main/java/jp/co/ha/root/contents/news/request/NewsEditApiRequest.java
+++ b/ha-root/src/main/java/jp/co/ha/root/contents/news/request/NewsEditApiRequest.java
@@ -2,6 +2,7 @@ package jp.co.ha.root.contents.news.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import jp.co.ha.business.dto.NewsListDto.Tag;
 import jp.co.ha.common.validator.annotation.Required;
 import jp.co.ha.root.base.BaseRootApiRequest;
 import jp.co.ha.web.form.BaseApiRequest;
@@ -29,14 +30,9 @@ public class NewsEditApiRequest extends BaseRootApiRequest implements BaseApiReq
     @JsonProperty("detail")
     @Required
     private String detail;
-    /** タグ色 */
-    @JsonProperty("tag_color")
-    @Required
-    private String tagColor;
-    /** タグ名 */
-    @JsonProperty("tag_name")
-    @Required
-    private String tagName;
+    /** タグ */
+    @JsonProperty("tag")
+    private Tag tag;
 
     /**
      * indexを返す
@@ -111,39 +107,22 @@ public class NewsEditApiRequest extends BaseRootApiRequest implements BaseApiReq
     }
 
     /**
-     * tagColorを返す
+     * tagを返す
      *
-     * @return tagColor
+     * @return tag
      */
-    public String getTagColor() {
-        return tagColor;
+    public Tag getTag() {
+        return tag;
     }
 
     /**
-     * tagColorを設定する
+     * tagを設定する
      *
-     * @param tagColor
+     * @param tag
+     *     タグ
      */
-    public void setTagColor(String tagColor) {
-        this.tagColor = tagColor;
-    }
-
-    /**
-     * tagNameを返す
-     *
-     * @return tagName
-     */
-    public String getTagName() {
-        return tagName;
-    }
-
-    /**
-     * tagNameを設定する
-     *
-     * @param tagName
-     */
-    public void setTagName(String tagName) {
-        this.tagName = tagName;
+    public void setTag(Tag tag) {
+        this.tag = tag;
     }
 
 }

--- a/ha-root/src/main/java/jp/co/ha/root/contents/news/request/NewsEntryApiRequest.java
+++ b/ha-root/src/main/java/jp/co/ha/root/contents/news/request/NewsEntryApiRequest.java
@@ -1,9 +1,8 @@
 package jp.co.ha.root.contents.news.request;
 
-import java.time.LocalDate;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import jp.co.ha.business.dto.NewsListDto.Tag;
 import jp.co.ha.root.base.BaseRootApiRequest;
 import jp.co.ha.web.form.BaseApiRequest;
 
@@ -12,23 +11,20 @@ import jp.co.ha.web.form.BaseApiRequest;
  *
  * @version 1.0.0
  */
-public class NewsEntiryApiRequest extends BaseRootApiRequest implements BaseApiRequest {
+public class NewsEntryApiRequest extends BaseRootApiRequest implements BaseApiRequest {
 
     /** タイトル */
     @JsonProperty("title")
     private String title;
     /** 日付 */
     @JsonProperty("date")
-    private LocalDate date;
+    private String date;
     /** 詳細 */
     @JsonProperty("detail")
     private String detail;
-    /** タグ色 */
-    @JsonProperty("tag_color")
-    private String tagColor;
-    /** タグ名 */
-    @JsonProperty("tag_name")
-    private String tagName;
+    /** タグ */
+    @JsonProperty("tag")
+    private Tag tag;
 
     /**
      * titleを返す
@@ -54,7 +50,7 @@ public class NewsEntiryApiRequest extends BaseRootApiRequest implements BaseApiR
      *
      * @return date
      */
-    public LocalDate getDate() {
+    public String getDate() {
         return date;
     }
 
@@ -64,7 +60,7 @@ public class NewsEntiryApiRequest extends BaseRootApiRequest implements BaseApiR
      * @param date
      *     日付
      */
-    public void setDate(LocalDate date) {
+    public void setDate(String date) {
         this.date = date;
     }
 
@@ -88,41 +84,22 @@ public class NewsEntiryApiRequest extends BaseRootApiRequest implements BaseApiR
     }
 
     /**
-     * tagColorを返す
+     * tagを返す
      *
-     * @return tagColor
+     * @return tag
      */
-    public String getTagColor() {
-        return tagColor;
+    public Tag getTag() {
+        return tag;
     }
 
     /**
-     * tagColorを設定する
+     * tagを設定する
      *
-     * @param tagColor
-     *     タグ色
+     * @param tag
+     *     タグ
      */
-    public void setTagColor(String tagColor) {
-        this.tagColor = tagColor;
-    }
-
-    /**
-     * tagNameを返す
-     *
-     * @return tagName
-     */
-    public String getTagName() {
-        return tagName;
-    }
-
-    /**
-     * tagNameを設定する
-     *
-     * @param tagName
-     *     タグ名
-     */
-    public void setTagName(String tagName) {
-        this.tagName = tagName;
+    public void setTag(Tag tag) {
+        this.tag = tag;
     }
 
 }

--- a/ha-root/src/main/java/jp/co/ha/root/contents/news/response/NewsEntryApiResponse.java
+++ b/ha-root/src/main/java/jp/co/ha/root/contents/news/response/NewsEntryApiResponse.java
@@ -12,7 +12,7 @@ import jp.co.ha.web.form.BaseApiResponse;
  *
  * @version 1.0.0
  */
-public class NewsEntiryApiResponse extends BaseRootApiResponse
+public class NewsEntryApiResponse extends BaseRootApiResponse
         implements BaseApiResponse {
 
     /** 登録したお知らせ情報 */

--- a/ha-root/src/main/java/jp/co/ha/root/contents/news/response/NewsListApiResponse.java
+++ b/ha-root/src/main/java/jp/co/ha/root/contents/news/response/NewsListApiResponse.java
@@ -61,12 +61,9 @@ public class NewsListApiResponse extends BaseRootApiResponse implements BaseApiR
         /** 詳細 */
         @JsonProperty("detail")
         private String detail;
-        /** タグ色 */
-        @JsonProperty("tag_color")
-        private String tagColor;
-        /** タグ名 */
-        @JsonProperty("tag_name")
-        private String tagName;
+        /** タグ */
+        @JsonProperty("tag")
+        private Tag tag;
 
         /**
          * indexを返す
@@ -145,42 +142,77 @@ public class NewsListApiResponse extends BaseRootApiResponse implements BaseApiR
         }
 
         /**
-         * tagColorを返す
+         * tagを返す
          *
-         * @return tagColor
+         * @return tag
          */
-        public String getTagColor() {
-            return tagColor;
+        public Tag getTag() {
+            return tag;
         }
 
         /**
-         * tagColorを設定する
+         * tagを設定する
          *
-         * @param tagColor
-         *     タグ色
+         * @param tag
+         *     タグ
          */
-        public void setTagColor(String tagColor) {
-            this.tagColor = tagColor;
+        public void setTag(Tag tag) {
+            this.tag = tag;
+        }
+
+    }
+
+    /**
+     * タグ情報
+     *
+     * @version 1.0.0
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Tag {
+
+        /** 色 */
+        @JsonProperty("color")
+        private String color;
+        /** 名前 */
+        @JsonProperty("name")
+        private String name;
+
+        /**
+         * colorを返す
+         *
+         * @return color
+         */
+        public String getColor() {
+            return color;
         }
 
         /**
-         * tagNameを返す
+         * colorを設定する
          *
-         * @return tagName
+         * @param color
+         *     色
          */
-        public String getTagName() {
-            return tagName;
+        public void setColor(String color) {
+            this.color = color;
         }
 
         /**
-         * tagNameを設定する
+         * nameを返す
          *
-         * @param tagName
-         *     タグ名
+         * @return name
          */
-        public void setTagName(String tagName) {
-            this.tagName = tagName;
+        public String getName() {
+            return name;
         }
 
+        /**
+         * nameを設定する
+         *
+         * @param name
+         *     名前
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
     }
 }

--- a/ha-root/src/main/java/jp/co/ha/root/contents/user/controller/UserEntryApiController.java
+++ b/ha-root/src/main/java/jp/co/ha/root/contents/user/controller/UserEntryApiController.java
@@ -2,7 +2,6 @@ package jp.co.ha.root.contents.user.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,7 +24,7 @@ import jp.co.ha.root.type.RootRoleType;
  * axios.postの場合で受け取る以下の方法ではリクエストのJSONをバインドできない<br>
  * <code>&#64;RequestBody MultiValueMap<String, Object> request</code><br>
  * そのためそのままRequestクラスで受け取る
- * 
+ *
  * @version 1.0.0
  */
 @RestController
@@ -50,7 +49,7 @@ public class UserEntryApiController
      *     ハッシュ化に失敗した場合
      */
     @PostMapping(value = "user/entry", produces = { MediaType.APPLICATION_JSON_VALUE })
-    public UserEntryApiResponse entry(@RequestBody MultiValueMap<String, Object> request)
+    public UserEntryApiResponse entry(@RequestBody UserEntryApiRequest request)
             throws BaseException {
 
         // TODO 妥当性チェックを追加
@@ -58,7 +57,7 @@ public class UserEntryApiController
         RootLoginInfo entity = new RootLoginInfo();
         entity.setRole(RootRoleType.REF.getValue());
         entity.setPassword(
-                hashEncoder.encode(request.get("password").get(0).toString(), ""));
+                hashEncoder.encode(request.getPassword(), ""));
         entity.setPasswordExpire(
                 DateTimeUtil.addMonth(DateTimeUtil.getSysDate().toLocalDate(), 6));
         entity.setDeleteFlag("0");

--- a/ha-root/src/main/java/jp/co/ha/root/contents/user/request/UserEntryApiRequest.java
+++ b/ha-root/src/main/java/jp/co/ha/root/contents/user/request/UserEntryApiRequest.java
@@ -1,5 +1,7 @@
 package jp.co.ha.root.contents.user.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import jp.co.ha.root.base.BaseRootApiRequest;
 import jp.co.ha.web.form.BaseApiRequest;
 
@@ -9,5 +11,50 @@ import jp.co.ha.web.form.BaseApiRequest;
  * @version 1.0.0
  */
 public class UserEntryApiRequest extends BaseRootApiRequest implements BaseApiRequest {
+
+    /** パスワード */
+    @JsonProperty("password")
+    private String password;
+    /** 確認用パスワード */
+    @JsonProperty("conf_password")
+    private String confPassword;
+
+    /**
+     * passwordを返す
+     *
+     * @return password
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * passwordを設定する
+     *
+     * @param password
+     *     パスワード
+     */
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    /**
+     * confPasswordを返す
+     *
+     * @return confPassword
+     */
+    public String getConfPassword() {
+        return confPassword;
+    }
+
+    /**
+     * confPasswordを設定する
+     *
+     * @param confPassword
+     *     確認用パスワード
+     */
+    public void setConfPassword(String confPassword) {
+        this.confPassword = confPassword;
+    }
 
 }

--- a/ha-web/src/main/java/jp/co/ha/web/view/BaseView.java
+++ b/ha-web/src/main/java/jp/co/ha/web/view/BaseView.java
@@ -1,7 +1,5 @@
 package jp.co.ha.web.view;
 
-import jp.co.ha.common.util.BreadcrumbView;
-
 /**
  * ViewEnumの基底インターフェース<br>
  * すべてのViewEnumはこのインターフェースを継承すること

--- a/ha-web/src/main/java/jp/co/ha/web/view/BreadcrumbView.java
+++ b/ha-web/src/main/java/jp/co/ha/web/view/BreadcrumbView.java
@@ -1,4 +1,4 @@
-package jp.co.ha.common.util;
+package jp.co.ha.web.view;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
- [x] お知らせ情報登録/編集画面のform部品をcomponent化
- [x] アカウント情報一覧画面に登録日時と更新日時を追加
- [x] API実行時にローディング画面を挟む
- [ ] 権限で画面の表示を制御
- [ ] アカウント情報編集機能を追加
- [ ] 健康情報編集機能を追加
- [x] お知らせ情報JSONの構造を修正