### PR TITLE
0007_管理者サイト構築

### DIFF
--- a/ha-business/src/main/java/jp/co/ha/business/db/crud/update/RootLoginInfoUpdateService.java
+++ b/ha-business/src/main/java/jp/co/ha/business/db/crud/update/RootLoginInfoUpdateService.java
@@ -1,10 +1,20 @@
 package jp.co.ha.business.db.crud.update;
 
+import jp.co.ha.db.entity.RootLoginInfo;
+
 /**
  * 管理者サイトユーザログイン情報更新サービスインターフェース
  *
  * @version 1.0.0
  */
 public interface RootLoginInfoUpdateService {
+
+    /**
+     * 管理者サイトユーザログイン情報を更新する
+     *
+     * @param entity
+     *     管理者サイトユーザログイン情報
+     */
+    void update(RootLoginInfo entity);
 
 }

--- a/ha-business/src/main/java/jp/co/ha/business/db/crud/update/impl/RootLoginInfoUpdateServiceImpl.java
+++ b/ha-business/src/main/java/jp/co/ha/business/db/crud/update/impl/RootLoginInfoUpdateServiceImpl.java
@@ -1,8 +1,14 @@
 package jp.co.ha.business.db.crud.update.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import jp.co.ha.business.db.crud.update.RootLoginInfoUpdateService;
+import jp.co.ha.common.db.annotation.Update;
+import jp.co.ha.db.entity.RootLoginInfo;
+import jp.co.ha.db.entity.RootLoginInfoExample;
+import jp.co.ha.db.entity.RootLoginInfoExample.Criteria;
 import jp.co.ha.db.mapper.RootLoginInfoMapper;
 
 /**
@@ -10,10 +16,24 @@ import jp.co.ha.db.mapper.RootLoginInfoMapper;
  *
  * @version 1.0.0
  */
+@Service
 public class RootLoginInfoUpdateServiceImpl implements RootLoginInfoUpdateService {
 
     /** 管理者サイトログイン情報Mapper */
     @Autowired
     private RootLoginInfoMapper mapper;
+
+    @Update
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void update(RootLoginInfo entity) {
+        RootLoginInfoExample example = new RootLoginInfoExample();
+        Criteria criteria = example.createCriteria();
+
+        // 管理者サイトログインID
+        criteria.andSeqRootLoginInfoIdEqualTo(entity.getSeqRootLoginInfoId());
+
+        mapper.updateByExampleSelective(entity, example);
+    }
 
 }

--- a/ha-db/src/main/java/jp/co/ha/db/entity/composite/CompositeRootUserInfo.java
+++ b/ha-db/src/main/java/jp/co/ha/db/entity/composite/CompositeRootUserInfo.java
@@ -1,6 +1,7 @@
 package jp.co.ha.db.entity.composite;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import jp.co.ha.common.db.annotation.Entity;
@@ -30,9 +31,15 @@ public class CompositeRootUserInfo extends RootLoginInfoKey implements Serializa
     private Integer seqRootUserRoleMngMtId;
     /** 管理者サイトユーザ権限詳細マスタID */
     private Integer seqRootUserRoleDetailMtId;
+    /** 削除フラグ */
+    private String deleteFlag;
     /** パスワード */
     @Mask
     private String password;
+    /** 登録日時 */
+    private LocalDate passwordExpire;
+    /** 備考 */
+    private String remarks;
     /** ユーザ権限 */
     private String role;
     /** ユーザ権限名 */
@@ -81,6 +88,25 @@ public class CompositeRootUserInfo extends RootLoginInfoKey implements Serializa
     }
 
     /**
+     * deleteFlagを返す
+     *
+     * @return deleteFlag
+     */
+    public String getDeleteFlag() {
+        return deleteFlag;
+    }
+
+    /**
+     * deleteFlagを設定する
+     *
+     * @param deleteFlag
+     *     削除フラグ
+     */
+    public void setDeleteFlag(String deleteFlag) {
+        this.deleteFlag = deleteFlag;
+    }
+
+    /**
      * passwordを返す
      *
      * @return password
@@ -97,6 +123,44 @@ public class CompositeRootUserInfo extends RootLoginInfoKey implements Serializa
      */
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    /**
+     * passwordExpireを返す
+     *
+     * @return passwordExpire
+     */
+    public LocalDate getPasswordExpire() {
+        return passwordExpire;
+    }
+
+    /**
+     * passwordExpireを設定する
+     *
+     * @param passwordExpire
+     *     パスワード有効期限
+     */
+    public void setPasswordExpire(LocalDate passwordExpire) {
+        this.passwordExpire = passwordExpire;
+    }
+
+    /**
+     * remarksを返す
+     *
+     * @return remarks
+     */
+    public String getRemarks() {
+        return remarks;
+    }
+
+    /**
+     * remarksを設定する
+     *
+     * @param remarks
+     *     備考
+     */
+    public void setRemarks(String remarks) {
+        this.remarks = remarks;
     }
 
     /**

--- a/ha-db/src/main/resources/jp/co/ha/db/mapper/composite/CompositeRootUserInfoMapper.xml
+++ b/ha-db/src/main/resources/jp/co/ha/db/mapper/composite/CompositeRootUserInfoMapper.xml
@@ -5,7 +5,10 @@
     <id column="SEQ_ROOT_LOGIN_INFO_ID" jdbcType="INTEGER" property="seqRootLoginInfoId" />
     <result column="SEQ_ROOT_USER_ROLE_MNG_MT_ID" jdbcType="INTEGER" property="seqRootUserRoleMngMtId" />
     <result column="SEQ_ROOT_USER_ROLE_DETAIL_MT_ID" jdbcType="INTEGER" property="seqRootUserRoleDetailMtId" />
+    <result column="DELETE_FLAG" jdbcType="VARCHAR" property="deleteFlag" />
     <result column="PASSWORD" jdbcType="VARCHAR" property="password" />
+    <result column="PASSWORD_EXPIRE" jdbcType="DATE" property="passwordExpire" />
+    <result column="REMARKS" jdbcType="VARCHAR" property="remarks" />
     <result column="ROLE" jdbcType="VARCHAR" property="role" />
     <result column="ROLE_NAME" jdbcType="VARCHAR" property="roleName" />
     <result column="REG_DATE" jdbcType="TIMESTAMP" property="regDate" />
@@ -17,7 +20,10 @@
       LI.SEQ_ROOT_LOGIN_INFO_ID
       , URM.SEQ_ROOT_USER_ROLE_MNG_MT_ID
       , URD.SEQ_ROOT_USER_ROLE_DETAIL_MT_ID
+      , LI.DELETE_FLAG
       , LI.PASSWORD
+      , LI.PASSWORD_EXPIRE
+      , LI.REMARKS
       , LI.REG_DATE
       , LI.UPDATE_DATE
       , RM.ROLE_NAME

--- a/ha-root/front/components/AppLoading.vue
+++ b/ha-root/front/components/AppLoading.vue
@@ -1,0 +1,26 @@
+<template>
+  <v-overlay :value="loading" :absolute="absolute">
+    <v-progress-circular
+      indeterminate
+      size="100"
+      width="7"
+      color="info"
+    ></v-progress-circular>
+  </v-overlay>
+</template>
+
+<script>
+export default {
+  props: {
+    loading: Boolean,
+  },
+  data: function () {
+    return {
+      absolute: false,
+    };
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/ha-root/front/components/AppLogout.vue
+++ b/ha-root/front/components/AppLogout.vue
@@ -14,6 +14,8 @@ export default {
   },
   methods: {
     logout: function () {
+      // vuex情報を削除
+      this.$store.commit("auth/clearToken");
       this.$auth.logout();
     },
   },

--- a/ha-root/front/components/news/NewsEdit.vue
+++ b/ha-root/front/components/news/NewsEdit.vue
@@ -65,12 +65,10 @@
             </v-btn>
           </v-card-actions>
           <ProcessFinishModal ref="finish" />
-          <v-overlay :value="loading">
-            <v-progress-circular indeterminate size="128"></v-progress-circular>
-          </v-overlay>
         </v-card>
       </v-col>
     </v-row>
+    <AppLoading :loading="loading" />
   </div>
 </template>
 
@@ -78,6 +76,7 @@
 import ProcessFinishModal from "~/components/modal/ProcessFinishModal.vue";
 import NewsTagPullDown from "~/components/news/NewsTagPullDown.vue";
 import AppMessageError from "~/components/AppMessageError.vue";
+import AppLoading from "~/components/AppLoading.vue";
 
 const axios = require("axios");
 let url = process.env.api_base_url + "news/";
@@ -87,6 +86,7 @@ export default {
     ProcessFinishModal,
     NewsTagPullDown,
     AppMessageError,
+    AppLoading,
   },
   props: {
     edit_news_form: Object,

--- a/ha-root/front/components/news/NewsEntry.vue
+++ b/ha-root/front/components/news/NewsEntry.vue
@@ -55,9 +55,7 @@
             </v-btn>
           </v-card-actions>
           <ProcessFinishModal ref="finish" />
-          <v-overlay :value="loading">
-            <v-progress-circular indeterminate size="128"></v-progress-circular>
-          </v-overlay>
+          <AppLoading :loading="loading" />
         </v-card>
       </v-col>
     </v-row>
@@ -68,6 +66,7 @@
 import ProcessFinishModal from "~/components/modal/ProcessFinishModal.vue";
 import NewsTagPullDown from "~/components/news/NewsTagPullDown.vue";
 import AppMessageError from "~/components/AppMessageError.vue";
+import AppLoading from "~/components/AppLoading.vue";
 
 const axios = require("axios");
 let url = process.env.api_base_url + "news";
@@ -77,6 +76,7 @@ export default {
     ProcessFinishModal,
     NewsTagPullDown,
     AppMessageError,
+    AppLoading,
   },
   data: function () {
     return {

--- a/ha-root/front/components/user/UserDataSave.vue
+++ b/ha-root/front/components/user/UserDataSave.vue
@@ -1,0 +1,33 @@
+<template></template>
+
+<script>
+const axios = require("axios");
+let retriveUrl = process.env.api_base_url + "user/";
+
+export default {
+  methods: {
+    save: function (seqLoginId) {
+      let headers = { Authorization: this.$store.state.auth.token };
+      axios.get(retriveUrl + seqLoginId, { headers }).then(
+        (response) => {
+          if (response.data.result == 0) {
+            // 正常終了した場合、storeにユーザ情報を保存
+            let userData = {
+              roles: response.data.roles,
+            };
+            this.$store.commit("auth/setUserData", userData);
+						return;
+          }
+					console.log("retrieve [error]=" + response.data.error.message);
+        },
+        (error) => {
+          console.log("retrieve [error]=" + error);
+        }
+      );
+    },
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/ha-root/front/components/user/UserRetrieve.vue
+++ b/ha-root/front/components/user/UserRetrieve.vue
@@ -5,36 +5,48 @@ const axios = require("axios");
 let retriveUrl = process.env.api_base_url + "user/";
 
 export default {
-  methods: {
-    retrieve: function (seqLoginId) {
-      console.log("★★★retrieve★★★");
-      let headers = { Authorization: this.$store.state.auth.token };
-      let apiResult = {
+  props: {
+    // RetrieveAPI対象のログインID
+    seqLoginId: String,
+  },
+  data: function () {
+    return {
+      apiResult: {
         result: false,
         message: null,
-      };
+        seqLoginId: null,
+        deleteFlag: false,
+        passwordExpire: null,
+        remarks: null,
+      },
+    };
+  },
+  mounted: function () {
+    this.retrieve(this.seqLoginId);
+    this.$emit("setRetrieveApiResult", this.apiResult);
+  },
+  methods: {
+    retrieve: function (seqLoginId) {
+      let headers = { Authorization: this.$store.state.auth.token };
       axios.get(retriveUrl + seqLoginId, { headers }).then(
         (response) => {
           if (response.data.result == 0) {
-            // 正常終了した場合
-            // storeにユーザ情報を保存
-            let userData = {
-              roles: response.data.roles,
-            };
-            this.$store.commit("auth/setUserData", userData);
-            apiResult.result = true;
+            this.apiResult.result = true;
+            this.apiResult.seqLoginId = response.data.seq_login_id.toString();
+            this.apiResult.deleteFlag = response.data.delete_flag == "1";
+            this.apiResult.passwordExpire = response.data.password_expire;
+            this.apiResult.remarks = response.data.remarks;
           } else {
-            apiResult.result = false;
-            apiResult.message = response.data.error.message;
+            this.apiResult.result = false;
+            this.apiResult.message = response.data.error.message;
           }
         },
         (error) => {
-          apiResult.result = false;
-          apiResult.message = error;
+          this.apiResult.result = false;
+          this.apiResult.message = error.toString();
           console.log("retrieve [error]=" + error);
         }
       );
-      return apiResult;
     },
   },
 };

--- a/ha-root/front/pages/account/index.vue
+++ b/ha-root/front/pages/account/index.vue
@@ -42,6 +42,7 @@
             <v-icon v-else-if="item.enclosure_char_flag == 0">mdi-minus</v-icon>
           </template>
         </v-data-table>
+        <AppLoading :loading="loading" />
       </v-col>
     </v-row>
   </div>
@@ -50,6 +51,7 @@
 <script>
 import AppTitle from "~/components/AppTitle.vue";
 import AppMessageError from "~/components/AppMessageError.vue";
+import AppLoading from "~/components/AppLoading.vue";
 
 const axios = require("axios");
 let url = process.env.api_base_url + "account";
@@ -58,6 +60,7 @@ export default {
   components: {
     AppTitle,
     AppMessageError,
+    AppLoading,
   },
   data: function () {
     return {
@@ -65,6 +68,7 @@ export default {
         hasError: false,
         message: null,
       },
+      loading: false,
       isRefShow: false,
       search: "",
       accountList: [],
@@ -133,6 +137,7 @@ export default {
       this.isRefShow = false;
     },
     getAccountList: function () {
+      this.loading = true;
       // 保存済のAPIトークンを取得
       let headers = {
         Authorization: this.$store.state.auth.token,
@@ -145,10 +150,12 @@ export default {
             this.error.hasError = true;
             this.error.message = response.data.error.message;
           }
+          this.loading = false;
         },
         (error) => {
           this.error.hasError = true;
           this.error.message = error;
+          this.loading = false;
           console.log("accountList [error]=" + error);
           return error;
         }

--- a/ha-root/front/pages/apidata/index.vue
+++ b/ha-root/front/pages/apidata/index.vue
@@ -61,6 +61,7 @@
             </v-chip>
           </template>
         </v-data-table>
+        <AppLoading :loading="loading" />
       </v-col>
     </v-row>
   </div>
@@ -69,6 +70,7 @@
 <script>
 import AppTitle from "~/components/AppTitle.vue";
 import AppMessageError from "~/components/AppMessageError.vue";
+import AppLoading from "~/components/AppLoading.vue";
 
 const axios = require("axios");
 let url = process.env.api_base_url + "apidata";
@@ -77,6 +79,7 @@ export default {
   components: {
     AppTitle,
     AppMessageError,
+    AppLoading,
   },
   data: function () {
     return {
@@ -84,6 +87,7 @@ export default {
         hasError: false,
         message: null,
       },
+      loading: false,
       isRefShow: false,
       timelines: [],
       search: "",
@@ -180,6 +184,7 @@ export default {
       this.isRefShow = false;
     },
     getApiDataList: function () {
+      this.loading = true;
       // 保存済のAPIトークンを取得
       let headers = {
         Authorization: this.$store.state.auth.token,
@@ -192,10 +197,12 @@ export default {
             this.error.hasError = true;
             this.error.message = response.data.error.message;
           }
+          this.loading = false;
         },
         (error) => {
           this.error.hasError = true;
           this.error.message = error;
+          this.loading = false;
           console.log("apidata [error]=" + error);
           return error;
         }

--- a/ha-root/front/pages/healthinfo/index.vue
+++ b/ha-root/front/pages/healthinfo/index.vue
@@ -16,6 +16,7 @@
           :items="healthInfoList"
           :search="search"
         ></v-data-table>
+        <AppLoading :loading="loading" />
       </v-col>
     </v-row>
   </div>
@@ -24,6 +25,7 @@
 <script>
 import AppTitle from "~/components/AppTitle.vue";
 import AppMessageError from "~/components/AppMessageError.vue";
+import AppLoading from "~/components/AppLoading.vue";
 
 const axios = require("axios");
 let url = process.env.api_base_url + "healthinfo";
@@ -32,6 +34,7 @@ export default {
   components: {
     AppTitle,
     AppMessageError,
+    AppLoading,
   },
   data: function () {
     return {
@@ -39,6 +42,7 @@ export default {
         hasError: false,
         message: null,
       },
+      loading: false,
       isRefShow: false,
       search: "",
       healthInfoList: [],
@@ -102,6 +106,7 @@ export default {
       this.isRefShow = false;
     },
     getHealthInfoList: function () {
+      this.loading = true;
       // 保存済のAPIトークンを取得
       let headers = {
         Authorization: this.$store.state.auth.token,
@@ -114,10 +119,12 @@ export default {
             this.error.hasError = true;
             this.error.message = response.data.error.message;
           }
+          this.loading = false;
         },
         (error) => {
           this.error.hasError = true;
           this.error.message = error;
+          this.loading = false;
           console.log("healthinfo [error]=" + error);
           return error;
         }

--- a/ha-root/front/pages/login/index.vue
+++ b/ha-root/front/pages/login/index.vue
@@ -26,12 +26,7 @@
             </v-form>
           </v-card-text>
           <v-card-actions>
-            <v-btn
-              color="primary"
-              @click="submit"
-              :loading="loading"
-              :disabled="loading"
-            >
+            <v-btn color="primary" @click="submit">
               <v-icon>mdi-account-arrow-right</v-icon>&ensp;ログイン
             </v-btn>
             <v-spacer />
@@ -40,7 +35,8 @@
             </v-btn>
           </v-card-actions>
         </v-card>
-        <UserRetrieve ref="user-retrieve" />
+        <UserRetrieve ref="userRetrieve" />
+        <AppLoading :loading="loading" />
       </v-col>
     </v-row>
   </div>
@@ -48,6 +44,7 @@
 
 <script>
 import AppMessageError from "~/components/AppMessageError.vue";
+import AppLoading from "~/components/AppLoading.vue";
 import UserRetrieve from "~/components/user/UserRetrieve.vue";
 
 export default {
@@ -55,6 +52,7 @@ export default {
   layout: "nonAuthLayout",
   components: {
     AppMessageError,
+    AppLoading,
     UserRetrieve,
   },
   data: function () {
@@ -90,9 +88,9 @@ export default {
       this.loading = true;
       if (!this.$refs.loginForm.validate()) {
         // 入力値エラーの場合
-        this.loading = false;
         return;
       }
+      this.loading = true;
       this.$auth
         .loginWith("local", {
           data: {
@@ -112,9 +110,7 @@ export default {
             });
 
             // ログイン成功時、ユーザ情報照会APIを実行
-            let retrieveResult = this.$refs.user-retrieve.retrieve(
-              this.seqLoginId
-            );
+            let retrieveResult = this.$refs.userRetrieve.retrieve(this.seqLoginId);
             if (retrieveResult.hasError) {
               this.error.hasError = true;
               this.error.message = retrieveResult.message;

--- a/ha-root/front/pages/login/index.vue
+++ b/ha-root/front/pages/login/index.vue
@@ -35,7 +35,7 @@
             </v-btn>
           </v-card-actions>
         </v-card>
-        <UserRetrieve ref="userRetrieve" />
+        <UserDataSave ref="userDataSave" />
         <AppLoading :loading="loading" />
       </v-col>
     </v-row>
@@ -45,7 +45,7 @@
 <script>
 import AppMessageError from "~/components/AppMessageError.vue";
 import AppLoading from "~/components/AppLoading.vue";
-import UserRetrieve from "~/components/user/UserRetrieve.vue";
+import UserDataSave from "~/components/user/UserDataSave.vue";
 
 export default {
   // ログイン前のレイアウトを適用
@@ -53,7 +53,7 @@ export default {
   components: {
     AppMessageError,
     AppLoading,
-    UserRetrieve,
+    UserDataSave,
   },
   data: function () {
     return {
@@ -109,12 +109,8 @@ export default {
               token: authorization,
             });
 
-            // ログイン成功時、ユーザ情報照会APIを実行
-            let retrieveResult = this.$refs.userRetrieve.retrieve(this.seqLoginId);
-            if (retrieveResult.hasError) {
-              this.error.hasError = true;
-              this.error.message = retrieveResult.message;
-            }
+            // ログイン成功時、storeにユーザ情報を保存
+            this.$refs.userDataSave.save(this.seqLoginId);
             this.loading = false;
             return response;
           },

--- a/ha-root/front/pages/news/index.vue
+++ b/ha-root/front/pages/news/index.vue
@@ -49,9 +49,7 @@
         </v-data-table>
         <ConfirmModal ref="confirm" />
         <ProcessFinishModal ref="finish" />
-        <v-overlay :value="loading">
-          <v-progress-circular indeterminate size="128"></v-progress-circular>
-        </v-overlay>
+        <AppLoading :loading="loading" />
       </v-col>
     </v-row>
   </div>
@@ -64,6 +62,7 @@ import ConfirmModal from "~/components/modal/ConfirmModal.vue";
 import ProcessFinishModal from "~/components/modal/ProcessFinishModal.vue";
 import AppTitle from "~/components/AppTitle.vue";
 import AppMessageError from "~/components/AppMessageError.vue";
+import AppLoading from "~/components/AppLoading.vue";
 
 const axios = require("axios");
 let url = process.env.api_base_url + "news";
@@ -76,6 +75,7 @@ export default {
     ProcessFinishModal,
     AppTitle,
     AppMessageError,
+    AppLoading,
   },
   data: function () {
     return {

--- a/ha-root/front/pages/news/index.vue
+++ b/ha-root/front/pages/news/index.vue
@@ -143,17 +143,25 @@ export default {
   },
   methods: {
     getNews: function () {
+      this.loading = true;
       axios
         .get(url, {
           headers: { Authorization: this.$store.state.auth.token },
         })
         .then(
           (response) => {
-            this.news_list = response.data.news_list;
+            if (response.data.result === "0") {
+              this.news_list = response.data.news_list;
+            } else {
+              this.error.hasError = true;
+              this.error.message = response.data.error.message;
+            }
+            this.loading = false;
           },
           (error) => {
             this.error.hasError = true;
             this.error.message = error;
+            this.loading = false;
             console.log("[error]=" + error);
             return error;
           }

--- a/ha-root/front/pages/user/edit/_seq_login_id.vue
+++ b/ha-root/front/pages/user/edit/_seq_login_id.vue
@@ -36,7 +36,8 @@
             </v-btn>
           </v-card-actions>
         </v-card>
-        <AppConfirm ref="confirm"></AppConfirm>
+        <AppConfirm ref="confirm" />
+        <AppLoading :loading="loading" />
         <UserRetrieve ref="userRetrieve" />
       </v-col>
     </v-row>
@@ -48,6 +49,7 @@ import AppConfirm from "~/components/modal/ConfirmModal.vue";
 import AppTitle from "~/components/AppTitle.vue";
 import AppMessageError from "~/components/AppMessageError.vue";
 import AppMessageSuccess from "~/components/AppMessageSuccess.vue";
+import AppLoading from "~/components/AppLoading.vue";
 import UserRetrieve from "~/components/user/UserRetrieve.vue";
 
 const axios = require("axios");
@@ -60,6 +62,7 @@ export default {
     AppTitle,
     AppMessageError,
     AppMessageSuccess,
+    AppLoading,
     UserRetrieve,
   },
   data: function () {
@@ -150,6 +153,7 @@ export default {
       );
     },
     getRoles: function () {
+      this.loading = true;
       let headers = {
         Authorization: this.$store.state.auth.token,
       };
@@ -161,10 +165,12 @@ export default {
             this.error.hasError = true;
             this.error.message = result.data.error.message;
           }
+          this.loading = false;
         },
         (error) => {
           this.error.hasError = true;
           this.error.message = error;
+          this.loading = false;
           console.log("roles [error]=" + error);
           return error;
         }

--- a/ha-root/front/pages/user/edit/_seq_login_id.vue
+++ b/ha-root/front/pages/user/edit/_seq_login_id.vue
@@ -4,16 +4,67 @@
     <AppMessageError v-if="error.hasError" :data="error" />
     <AppMessageSuccess v-if="apiResult.isSuccess" :data="apiResult" />
     <v-row justify="center" align="center">
-      <v-col class="text-center" cols="12" sm="8" md="6">
+      <v-col class="text-center" cols="12" sm="8" md="8">
         <v-card>
-          <v-card-text>
-            <v-form ref="editForm">
+          <v-form ref="editForm">
+            <v-card-text>
               <v-text-field
                 v-model="editUserForm.seqLoginId"
                 label="更新対象の管理者ユーザのログインID"
                 disabled
                 >{{ editUserForm.seqLoginId }}</v-text-field
               >
+            </v-card-text>
+            <v-card-title>削除フラグ</v-card-title>
+            <v-card-text>
+              <v-switch
+                :label="!editUserForm.deleteFlag ? '削除しない' : '削除する'"
+                v-model="editUserForm.deleteFlag"
+              ></v-switch>
+            </v-card-text>
+
+            <v-card-title>パスワード</v-card-title>
+            <v-card-text>
+              <v-text-field
+                v-model="editUserForm.password"
+                label="更新後パスワード"
+                clearable
+                >{{ editUserForm.password }}</v-text-field
+              >
+            </v-card-text>
+
+            <v-card-title>パスワード有効期限</v-card-title>
+            <v-card-text>
+              <v-text-field
+                v-model="editUserForm.passwordExpire"
+                label="日付"
+                hint="年/月/日"
+                persistent-hint
+                @click="isDispCalendar = !isDispCalendar"
+                clearable
+                :rules="[required]"
+              ></v-text-field>
+              <template v-if="isDispCalendar">
+                <v-date-picker
+                  v-model="editUserForm.passwordExpire"
+                  no-title
+                  @input="isDispCalendar = !isDispCalendar"
+                ></v-date-picker>
+              </template>
+            </v-card-text>
+
+            <v-card-title>備考</v-card-title>
+            <v-card-text>
+              <v-textarea
+                v-model="editUserForm.remarks"
+                label="備考"
+                clearable
+                >{{ editUserForm.remarks }}</v-textarea
+              >
+            </v-card-text>
+
+            <v-card-title>権限</v-card-title>
+            <v-card-text>
               <v-checkbox
                 v-model="editUserForm.roles"
                 v-for="(role, i) in roles"
@@ -23,22 +74,23 @@
                 :rules="[required]"
                 hide-details
               ></v-checkbox>
-            </v-form>
-          </v-card-text>
-          <v-card-actions>
-            <v-btn
-              color="primary"
-              @click="openUserEditModal"
-              :loading="loading"
-              :disabled="loading"
-            >
-              <v-icon>mdi-comment-edit</v-icon>&ensp;更新
-            </v-btn>
-          </v-card-actions>
+              <br />
+              <v-divider />
+            </v-card-text>
+            <v-card-actions>
+              <v-btn color="primary" @click="openUserEditModal">
+                <v-icon>mdi-comment-edit</v-icon>&ensp;更新
+              </v-btn>
+            </v-card-actions>
+          </v-form>
         </v-card>
         <AppConfirm ref="confirm" />
         <AppLoading :loading="loading" />
-        <UserRetrieve ref="userRetrieve" />
+        <UserRetrieve
+          :seqLoginId="editUserForm.seqLoginId"
+          @setRetrieveApiResult="setRetrieveApiResult"
+        />
+        <UserDataSave ref="userDataSave" />
       </v-col>
     </v-row>
   </div>
@@ -51,6 +103,7 @@ import AppMessageError from "~/components/AppMessageError.vue";
 import AppMessageSuccess from "~/components/AppMessageSuccess.vue";
 import AppLoading from "~/components/AppLoading.vue";
 import UserRetrieve from "~/components/user/UserRetrieve.vue";
+import UserDataSave from "~/components/user/UserDataSave.vue";
 
 const axios = require("axios");
 let url = process.env.api_base_url + "user/";
@@ -64,6 +117,7 @@ export default {
     AppMessageSuccess,
     AppLoading,
     UserRetrieve,
+    UserDataSave,
   },
   data: function () {
     return {
@@ -77,8 +131,13 @@ export default {
         message: "",
       },
       required: (value) => !!value || "必ず入力してください",
+      isDispCalendar: false,
       editUserForm: {
         seqLoginId: null,
+        deleteFlag: false,
+        password: null,
+        passwordExpire: null,
+        remarks: null,
         roles: [],
       },
       roles: [],
@@ -99,7 +158,8 @@ export default {
           width: 400,
         })
       ) {
-        this.sendUserEdit();
+        // ユーザ情報更新API実行
+        this.updateUser();
       }
     },
     validate: function () {
@@ -114,7 +174,7 @@ export default {
       }
       return null;
     },
-    sendUserEdit: function () {
+    updateUser: function () {
       this.loading = true;
       let headers = {
         Authorization: this.$store.state.auth.token,
@@ -122,21 +182,14 @@ export default {
       let reqUrl = url + this.editUserForm.seqLoginId;
       let reqBody = {
         roles: this.editUserForm.roles,
+        remarks: this.editUserForm.remarks,
       };
       axios.put(reqUrl, reqBody, { headers }).then(
         (result) => {
-          if (result.data.result === "0") {
+          if (result.data.result == "0") {
             this.apiResult.isSuccess = true;
             this.apiResult.message = "更新完了";
-
-            // ユーザ情報照会APIを実行
-            let retrieveResult = this.$refs.userRetrieve.retrieve(
-              this.editUserForm.seqLoginId
-            );
-            if (retrieveResult.hasError) {
-              this.error.hasError = true;
-              this.error.message = retrieveResult.message;
-            }
+            this.saveUpdateData();
           } else {
             this.error.hasError = true;
             this.error.message = result.data.error.message;
@@ -147,7 +200,7 @@ export default {
           this.loading = false;
           this.error.hasError = true;
           this.error.message = error;
-          console.log("[error]=" + error);
+          console.log("user update [error]=" + error);
           return error;
         }
       );
@@ -176,12 +229,20 @@ export default {
         }
       );
     },
+    saveUpdateData: function () {
+      this.$refs.userDataSave.save(this.editUserForm.seqLoginId);
+    },
+    setRetrieveApiResult: function (retrieveApiResult) {
+      this.editUserForm = retrieveApiResult;
+    },
+  },
+  created: function () {
+    // ログインID
+    this.editUserForm.seqLoginId = this.$store.state.auth.seq_login_id;
   },
   mounted: function () {
     // 権限リスト
     this.getRoles();
-    // ログインID
-    this.editUserForm.seqLoginId = this.$store.state.auth.seq_login_id;
     // ユーザ権限
     this.editUserForm.roles = this.$store.state.auth.roles.map(
       (item) => item.value

--- a/ha-root/front/pages/user/entry/index.vue
+++ b/ha-root/front/pages/user/entry/index.vue
@@ -1,74 +1,70 @@
 <template>
-  <v-row justify="center" align="center">
-    <v-col class="text-center" cols="12" sm="8" md="6">
-      <br /><br />
-      <v-card>
-        <v-card-title>{{ title }}</v-card-title>
-        <v-card-text>
-          <v-form ref="entryForm">
-            <v-text-field
-              v-model="password"
-              label="パスワード"
-              prepend-icon="mdi-lock"
-              :append-icon="password_toggle.password_icon"
-              :type="password_toggle.password_type"
-              @click:append="password_show = !password_show"
-              :rules="[required]"
-            ></v-text-field>
-            <v-text-field
-              v-model="conf_password"
-              label="確認用パスワード"
-              prepend-icon="mdi-lock"
-              :append-icon="conf_password_toggle.conf_password_icon"
-              :type="conf_password_toggle.conf_password_type"
-              @click:append="conf_password_show = !conf_password_show"
-              :rules="[required]"
-            ></v-text-field>
-          </v-form>
-          <v-card-text v-if="api_data.api_result === '0'">
-            以下の情報をログイン画面より入力し、ログインしてください
-            <ul>
-              <li>ログインID = {{ api_data.seq_login_id }}</li>
-              <li>パスワード = {{ this.password }}</li>
-            </ul>
+  <div>
+    <AppMessageError v-if="error.hasError" :data="error" />
+    <v-row justify="center" align="center">
+      <v-col class="text-center" cols="12" sm="8" md="6">
+        <br />
+        <br />
+        <v-card>
+          <v-card-title>{{ title }}</v-card-title>
+          <v-card-text>
+            <v-form ref="entryForm">
+              <v-text-field
+                v-model="password"
+                label="パスワード"
+                prepend-icon="mdi-lock"
+                :append-icon="passwordToggle.passwordIcon"
+                :type="passwordToggle.passwordType"
+                @click:append="passwordShow = !passwordShow"
+                :rules="[required]"
+              ></v-text-field>
+              <v-text-field
+                v-model="confPassword"
+                label="確認用パスワード"
+                prepend-icon="mdi-lock"
+                :append-icon="confPasswordToggle.confPasswordIcon"
+                :type="confPasswordToggle.confPasswordType"
+                @click:append="confPasswordShow = !confPasswordShow"
+                :rules="[required]"
+              ></v-text-field>
+            </v-form>
+            <v-card-text v-if="api_data.api_result === '0'">
+              以下の情報をログイン画面より入力し、ログインしてください
+              <ul>
+                <li>ログインID = {{ api_data.seq_login_id }}</li>
+                <li>パスワード = {{ this.password }}</li>
+              </ul>
+            </v-card-text>
           </v-card-text>
-        </v-card-text>
-        <v-card-actions>
-          <template v-if="api_data.api_result != '0'">
-            <!-- APIが正常終了していない場合 -->
-            <v-btn
-              color="primary"
-              @click="openUserEntryModal"
-              v-on="on"
-              :loading="loading"
-              :disabled="loading"
-            >
-              <v-icon>mdi-account-multiple-plus</v-icon>&ensp;作成
-            </v-btn>
-          </template>
-          <template v-else>
-            <!-- APIが正常終了している場合 -->
-            <v-btn
-              color="primary"
-              to="/login"
-              :loading="loading"
-              :disabled="loading"
-            >
-              <v-icon>mdi-account-arrow-right</v-icon>&ensp;ログイン
-            </v-btn>
-          </template>
-          <v-btn color="accent" @click="reset">
-            <v-icon>mdi-alert</v-icon>&ensp;リセット
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-      <AppConfirm ref="confirm"></AppConfirm>
-    </v-col>
-  </v-row>
+          <v-card-actions>
+            <template v-if="api_data.api_result != '0'">
+              <!-- APIが正常終了していない場合 -->
+              <v-btn color="primary" @click="openUserEntryModal">
+                <v-icon>mdi-account-multiple-plus</v-icon>&ensp;作成
+              </v-btn>
+              <v-btn color="accent" @click="reset">
+                <v-icon>mdi-alert</v-icon>&ensp;リセット
+              </v-btn>
+            </template>
+            <template v-else>
+              <!-- APIが正常終了している場合 -->
+              <v-btn color="primary" to="/login">
+                <v-icon>mdi-account-arrow-right</v-icon>&ensp;ログイン
+              </v-btn>
+            </template>
+          </v-card-actions>
+        </v-card>
+        <AppConfirm ref="confirm" />
+        <AppLoading :loading="loading" />
+      </v-col>
+    </v-row>
+  </div>
 </template>
 
 <script>
 import AppConfirm from "~/components/modal/ConfirmModal.vue";
+import AppMessageError from "~/components/AppMessageError.vue";
+import AppLoading from "~/components/AppLoading.vue";
 
 const axios = require("axios");
 let url = process.env.api_base_url + "user";
@@ -80,43 +76,45 @@ export default {
   auth: false,
   components: {
     AppConfirm,
+    AppMessageError,
+    AppLoading,
   },
   data: function () {
     return {
       title: "管理ユーザ作成",
+      error: {
+        hasError: false,
+        message: null,
+      },
       password: "",
-      conf_password: "",
-      password_show: false,
-      conf_password_show: false,
+      confPassword: "",
+      passwordShow: false,
+      confPasswordShow: false,
       required: (value) => !!value || "必ず入力してください",
       loading: false,
       api_data: {
         api_result: "",
         seq_login_id: "",
       },
-      modal: {
-        title: "ユーザ作成",
-        contents: "",
-      },
     };
   },
   computed: {
-    password_toggle: function () {
-      const password_icon = this.password_show ? "mdi-eye" : "mdi-eye-off";
-      const password_type = this.password_show ? "text" : "password";
+    passwordToggle: function () {
+      const passwordIcon = this.passwordShow ? "mdi-eye" : "mdi-eye-off";
+      const passwordType = this.passwordShow ? "text" : "password";
       return {
-        password_icon,
-        password_type,
+        passwordIcon,
+        passwordType,
       };
     },
-    conf_password_toggle: function () {
-      const conf_password_icon = this.conf_password_show
+    confPasswordToggle: function () {
+      const confPasswordIcon = this.confPasswordShow
         ? "mdi-eye"
         : "mdi-eye-off";
-      const conf_password_type = this.conf_password_show ? "text" : "password";
+      const confPasswordType = this.confPasswordShow ? "text" : "password";
       return {
-        conf_password_icon,
-        conf_password_type,
+        confPasswordIcon,
+        confPasswordType,
       };
     },
   },
@@ -131,7 +129,7 @@ export default {
       }
 
       if (
-        await this.$refs.confirm.open(this.modal.title, this.modal.contents, {
+        await this.$refs.confirm.open("ユーザ作成", "", {
           color: "blue",
           width: 400,
         })
@@ -144,20 +142,31 @@ export default {
       }
     },
     entryUser: function () {
+      this.loading = true;
       let reqBody = {
         password: this.password,
         conf_password: this.conf_password,
       };
-
-      this.loading = true;
-      axios.post(url, reqBody).then((result) => {
-        if (result.data.result === "0") {
-          // ユーザ作成APIが正常終了した場合
-          this.api_data.api_result = result.data.result;
-          this.api_data.seq_login_id = result.data.seq_login_id;
+      axios.post(url, reqBody).then(
+        (result) => {
+          if (result.data.result === "0") {
+            // ユーザ作成APIが正常終了した場合
+            this.api_data.api_result = result.data.result;
+            this.api_data.seq_login_id = result.data.seq_login_id;
+          } else {
+            this.error.hasError = true;
+            this.error.message = response.data.error.message;
+          }
           this.loading = false;
+        },
+        (error) => {
+          this.error.hasError = true;
+          this.error.message = error;
+          this.loading = false;
+          console.log("userentry [error]=" + error);
+          return error;
         }
-      });
+      );
     },
   },
 };

--- a/ha-root/src/main/java/jp/co/ha/root/contents/user/controller/UserEditApiController.java
+++ b/ha-root/src/main/java/jp/co/ha/root/contents/user/controller/UserEditApiController.java
@@ -19,8 +19,11 @@ import jp.co.ha.business.db.crud.create.RootUserRoleDetailMtCreateService;
 import jp.co.ha.business.db.crud.delete.RootUserRoleDetailMtDeleteService;
 import jp.co.ha.business.db.crud.read.RootLoginInfoSearchService;
 import jp.co.ha.business.db.crud.read.RootRoleMtSearchService;
+import jp.co.ha.business.db.crud.update.RootLoginInfoUpdateService;
 import jp.co.ha.common.log.Logger;
 import jp.co.ha.common.log.LoggerFactory;
+import jp.co.ha.common.util.BeanUtil;
+import jp.co.ha.db.entity.RootLoginInfo;
 import jp.co.ha.db.entity.RootRoleMt;
 import jp.co.ha.db.entity.RootUserRoleDetailMt;
 import jp.co.ha.db.entity.composite.CompositeRootUserInfo;
@@ -46,6 +49,9 @@ public class UserEditApiController
     /** 管理者サイトユーザログイン情報検索サービス */
     @Autowired
     private RootLoginInfoSearchService rootLoginInfoSearchService;
+    /** 管理者サイトユーザログイン情報更新サービス */
+    @Autowired
+    private RootLoginInfoUpdateService rootLoginInfoUpdateService;
     /** 管理者サイトユーザ権限詳細マスタ削除サービス */
     @Autowired
     private RootUserRoleDetailMtDeleteService rootUserRoleDetailMtDeleteService;
@@ -111,6 +117,16 @@ public class UserEditApiController
                 mt.setSeqRootRoleMtId(roleMt.getSeqRootRoleMtId());
                 rootUserRoleDetailMtCreateService.create(mt);
             }
+
+            // 管理者サイトユーザログイン情報を更新
+            // 結合しているので権限情報以外はここから取得する
+            CompositeRootUserInfo userRole = userRoleList.get(0);
+            RootLoginInfo entity = new RootLoginInfo();
+            BeanUtil.copy(userRole, entity);
+            if (request.getRemarks() != null) {
+                entity.setRemarks(request.getRemarks());
+            }
+            rootLoginInfoUpdateService.update(entity);
 
             // 正常にDB登録出来た場合、コミット
             transactionManager.commit(status);

--- a/ha-root/src/main/java/jp/co/ha/root/contents/user/controller/UserRetrieveController.java
+++ b/ha-root/src/main/java/jp/co/ha/root/contents/user/controller/UserRetrieveController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import jp.co.ha.business.db.crud.read.RootLoginInfoSearchService;
+import jp.co.ha.common.util.BeanUtil;
 import jp.co.ha.common.util.CollectionUtil;
 import jp.co.ha.db.entity.composite.CompositeRootUserInfo;
 import jp.co.ha.root.base.BaseRootApiController;
@@ -60,6 +61,9 @@ public class UserRetrieveController
             return response;
         }
 
+        // 結合しているので権限情報以外はここから取得する
+        CompositeRootUserInfo entity = entityList.get(0);
+
         UserRetrieveApiResponse response = new UserRetrieveApiResponse();
         response.setRootApiResult(RootApiResult.SUCCESS);
         response.setSeqLoginId(seqLoginId);
@@ -69,6 +73,7 @@ public class UserRetrieveController
             role.setLabel(e.getRoleName());
             return role;
         }).collect(Collectors.toList()));
+        BeanUtil.copy(entity, response);
 
         return response;
     }

--- a/ha-root/src/main/java/jp/co/ha/root/contents/user/request/UserEditApiRequest.java
+++ b/ha-root/src/main/java/jp/co/ha/root/contents/user/request/UserEditApiRequest.java
@@ -18,6 +18,9 @@ public class UserEditApiRequest extends BaseRootApiRequest implements BaseApiReq
     /** 権限 */
     @JsonProperty("roles")
     private List<RootRoleType> roles;
+    /** 備考 */
+    @JsonProperty("remarks")
+    private String remarks;
 
     /**
      * rolesを返す
@@ -32,9 +35,29 @@ public class UserEditApiRequest extends BaseRootApiRequest implements BaseApiReq
      * rolesを設定する
      *
      * @param roles
+     *     権限
      */
     public void setRoles(List<RootRoleType> roles) {
         this.roles = roles;
+    }
+
+    /**
+     * remarksを返す
+     *
+     * @return remarks
+     */
+    public String getRemarks() {
+        return remarks;
+    }
+
+    /**
+     * remarksを設定する
+     *
+     * @param remarks
+     *     備考
+     */
+    public void setRemarks(String remarks) {
+        this.remarks = remarks;
     }
 
 }

--- a/ha-root/src/main/java/jp/co/ha/root/contents/user/response/UserRetrieveApiResponse.java
+++ b/ha-root/src/main/java/jp/co/ha/root/contents/user/response/UserRetrieveApiResponse.java
@@ -1,8 +1,12 @@
 package jp.co.ha.root.contents.user.response;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 
 import jp.co.ha.root.base.BaseRootApiResponse;
 import jp.co.ha.root.contents.tools.response.RoleMtListApiResponse.Role;
@@ -22,6 +26,17 @@ public class UserRetrieveApiResponse extends BaseRootApiResponse
     /** 権限リスト */
     @JsonProperty("roles")
     private List<Role> roles;
+    /** 削除フラグ */
+    @JsonProperty("delete_flag")
+    private String deleteFlag;
+    /** パスワード有効期限 */
+    @JsonProperty("password_expire")
+    @JsonSerialize(using = LocalDateSerializer.class)
+    @JsonFormat(pattern = "yyyy/MM/dd", timezone = "Asia/Tokyo")
+    private LocalDate passwordExpire;
+    /** 備考 */
+    @JsonProperty("remarks")
+    private String remarks;
 
     /**
      * seqLoginIdを返す
@@ -59,6 +74,63 @@ public class UserRetrieveApiResponse extends BaseRootApiResponse
      */
     public void setRoles(List<Role> roles) {
         this.roles = roles;
+    }
+
+    /**
+     * deleteFlagを返す
+     *
+     * @return deleteFlag
+     */
+    public String getDeleteFlag() {
+        return deleteFlag;
+    }
+
+    /**
+     * deleteFlagを設定する
+     *
+     * @param deleteFlag
+     *     削除フラグ
+     */
+    public void setDeleteFlag(String deleteFlag) {
+        this.deleteFlag = deleteFlag;
+    }
+
+    /**
+     * passwordExpireを返す
+     *
+     * @return passwordExpire
+     */
+    public LocalDate getPasswordExpire() {
+        return passwordExpire;
+    }
+
+    /**
+     * passwordExpireを設定する
+     *
+     * @param passwordExpire
+     *     パスワード有効期限
+     */
+    public void setPasswordExpire(LocalDate passwordExpire) {
+        this.passwordExpire = passwordExpire;
+    }
+
+    /**
+     * remarksを返す
+     *
+     * @return remarks
+     */
+    public String getRemarks() {
+        return remarks;
+    }
+
+    /**
+     * remarksを設定する
+     *
+     * @param remarks
+     *     備考
+     */
+    public void setRemarks(String remarks) {
+        this.remarks = remarks;
     }
 
 }


### PR DESCRIPTION
## Issue
https://github.com/kohei-okazaki/work-3g/issues/556

## 修正内容
- ローディングをcomponent化
- RetrieveAPIの呼び出し方が正しくなかったため修正
- ログアウト時、vuex内の情報を削除
- ユーザ情報更新APIに権限以外の項目も更新できるように修正（一旦、備考のみ）
- RetrieveAPIを呼んでVuexに保存するcomponent（UserRetrieve.vue ）をそのままユーザ情報更新画面に遷移時に呼び出すと、メソッドの戻り値が帰ってこない。そのため、以下でcomponentを分ける（それぞれでRetrieveAPIを呼び出す処理を記載しているが他に方法がないため）
1. 親コンポーネントから子コンポーネントのメソッド（RetrieveAPIを呼んでVuexまで保存(子コンポーネントのメソッドを呼び出し時は戻り値なし)）
2. 親コンポーネントから子コンポーネントのmountedで呼び出し時、RetrieveAPIを呼んで親コンポーネントの変数にbindする

## 対象サーバ
- [ ] ha-dashboard
- [ ] ha-api
- [ ] ha-node
- [x] ha-root
