### PR TITLE
修正

### DIFF
--- a/ha-api/src/main/java/jp/co/ha/api/exception/RestApiExceptionHandler.java
+++ b/ha-api/src/main/java/jp/co/ha/api/exception/RestApiExceptionHandler.java
@@ -1,9 +1,5 @@
 package jp.co.ha.api.exception;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,7 +22,6 @@ import jp.co.ha.common.exception.BaseExceptionHandler;
 import jp.co.ha.common.exception.CommonErrorCode;
 import jp.co.ha.common.log.Logger;
 import jp.co.ha.common.log.LoggerFactory;
-import jp.co.ha.common.type.Charset;
 
 /***
  * REST APIの例外ハンドラークラス<br>
@@ -52,18 +47,14 @@ public class RestApiExceptionHandler extends BaseExceptionHandler {
      *     APIで発生した例外
      * @return クライアントへ返すレスポンス
      */
-    @ResponseStatus(code = HttpStatus.OK)
     @ExceptionHandler(Exception.class)
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
     public BaseAppApiResponse handleException(Exception e) {
 
         // Slackに通知
-        try (StringWriter sw = new StringWriter();
-                PrintWriter pw = new PrintWriter(sw);) {
-            e.printStackTrace(pw);
-            slackApiComponent.sendFile(ContentType.DASHBOARD,
-                    sw.toString().getBytes(Charset.UTF_8.getValue()), "エラー情報",
-                    "stack-trace", super.getLogErrorMessage(e));
-        } catch (BaseException | IOException be) {
+        try {
+            slackApiComponent.send(ContentType.API, super.getLogErrorMessage(e));
+        } catch (BaseException be) {
             LOG.error("slack通知に失敗しました", be);
         }
 

--- a/ha-business/src/main/java/jp/co/ha/business/api/slack/SlackApiComponent.java
+++ b/ha-business/src/main/java/jp/co/ha/business/api/slack/SlackApiComponent.java
@@ -95,9 +95,10 @@ public class SlackApiComponent {
     public void sendFile(ContentType contentType, byte[] data, String fileName,
             String title, String initialComment) throws BaseException {
 
+        SlackSession session = null;
         try {
             Connection conn = getConnectionByContentType(contentType);
-            SlackSession session = SlackSessionFactory
+            session = SlackSessionFactory
                     .createWebSocketSlackSession(conn.getToken());
 
             session.connect();
@@ -108,9 +109,16 @@ public class SlackApiComponent {
                     initialComment);
             LOG.debug("送信終了");
 
-            session.disconnect();
         } catch (IOException e) {
             throw new BusinessException(e);
+        } finally {
+            if (session != null) {
+                try {
+                    session.disconnect();
+                } catch (IOException e) {
+                    throw new BusinessException(e);
+                }
+            }
         }
     }
 

--- a/ha-dashboard/src/main/java/jp/co/ha/dashboard/exception/DashboardExceptionHandler.java
+++ b/ha-dashboard/src/main/java/jp/co/ha/dashboard/exception/DashboardExceptionHandler.java
@@ -1,8 +1,5 @@
 package jp.co.ha.dashboard.exception;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.Locale;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,7 +17,6 @@ import jp.co.ha.common.exception.BaseException;
 import jp.co.ha.common.exception.BaseExceptionHandler;
 import jp.co.ha.common.log.Logger;
 import jp.co.ha.common.log.LoggerFactory;
-import jp.co.ha.common.type.Charset;
 import jp.co.ha.dashboard.view.DashboardView;
 
 /**
@@ -49,15 +45,13 @@ public class DashboardExceptionHandler extends BaseExceptionHandler
         // log出力
         outLog(logErrorMessage, e);
 
-        try (StringWriter sw = new StringWriter();
-                PrintWriter pw = new PrintWriter(sw);) {
-            e.printStackTrace(pw);
-            slackApiComponent.sendFile(ContentType.DASHBOARD,
-                    sw.toString().getBytes(Charset.UTF_8.getValue()), "エラー情報",
-                    "stack-trace", logErrorMessage);
-        } catch (BaseException | IOException be) {
+        // Slackに通知
+        try {
+            slackApiComponent.send(ContentType.DASHBOARD, logErrorMessage);
+        } catch (BaseException be) {
             LOG.error("slack通知に失敗しました", be);
         }
+
         request.setAttribute("errorMessage", getDispErrorMessage(e));
 
         return modelView;


### PR DESCRIPTION
### Issue
https://github.com/kohei-okazaki/work-3g/issues/992

### 修正内容
- slack通知を一時的にファイル送信ではなくメッセージ通知に変更。TODO 将来的にslackAPIライブラリは公式のものに変更する予定。

### 対象サーバ
- [x] ha-dashboard
- [x] ha-api
- [ ] ha-batch
- [ ] ha-node
- [ ] ha-root
- [ ] ha-docs
- [ ] ha-track
